### PR TITLE
Fix memory leak

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -6046,6 +6046,7 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
         } catch (Exception e) {
             FileLog.e(e);
         }
+        clearFragments();
         super.onDestroy();
         onFinish();
         FloatingDebugController.onDestroy();


### PR DESCRIPTION
fix memory leak in LaunchActivity when onDestroy() method from LaunchActivity called but onFragmentDestroy() from DialogsActivity doesn't called and this causes a memory leak


copy: https://github.com/DrKLO/Telegram/pull/1797