### PR TITLE
Some improvements to External Sticker Cache

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaDataController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaDataController.java
@@ -1953,9 +1953,6 @@ public class MediaDataController extends BaseController {
         loadHash[type] = calcStickersHash(stickerSets[type]);
         getNotificationCenter().postNotificationName(NotificationCenter.stickersDidLoad, type, true);
         loadStickers(type, false, true);
-
-        // Na: [ExternalStickerCache] cache sticker sets
-        ExternalStickerCacheHelper.cacheStickers();
     }
 
     public void loadFeaturedStickers(boolean emoji, boolean cache, boolean force) {
@@ -2726,9 +2723,6 @@ public class MediaDataController extends BaseController {
                 }));
             }
         }
-
-        // Na: [ExternalStickerCache] cache sticker sets
-        ExternalStickerCacheHelper.cacheStickers();
     }
 
     private void putStickersToCache(int type, ArrayList<TLRPC.TL_messages_stickerSet> stickers, int date, long hash) {
@@ -2764,9 +2758,6 @@ public class MediaDataController extends BaseController {
             } catch (Exception e) {
                 FileLog.e(e);
             }
-
-            // Na: [ExternalStickerCache] cache sticker sets
-            ExternalStickerCacheHelper.cacheStickers();
         });
     }
 
@@ -3125,9 +3116,6 @@ public class MediaDataController extends BaseController {
         }
 
         getNotificationCenter().postNotificationName(NotificationCenter.stickersDidLoad, type, true);
-
-        // Na: [ExternalStickerCache] cache sticker sets
-        ExternalStickerCacheHelper.cacheStickers();
     }
 
     public void removeMultipleStickerSets(Context context, BaseFragment fragment, ArrayList<TLRPC.TL_messages_stickerSet> sets) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/StickerMasksAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/StickerMasksAlert.java
@@ -1166,9 +1166,6 @@ public class StickerMasksAlert extends BottomSheet implements NotificationCenter
             stickersTab.onPageScrolled(lastPosition, lastPosition);
         }
         checkPanels();
-
-        // Na: [ExternalStickerCache] cache sticker sets
-        ExternalStickerCacheHelper.cacheStickers();
     }
 
     private void checkPanels() {

--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -231,6 +231,7 @@ import tw.nekomimi.nekogram.utils.AlertUtil;
 import tw.nekomimi.nekogram.utils.ProxyUtil;
 import tw.nekomimi.nekogram.utils.UIUtil;
 import xyz.nextalone.nagram.NaConfig;
+import xyz.nextalone.nagram.helper.ExternalStickerCacheHelper;
 
 public class LaunchActivity extends BasePermissionsActivity implements INavigationLayout.INavigationLayoutDelegate, NotificationCenter.NotificationCenterDelegate, DialogsActivity.DialogsActivityDelegate {
     public final static String EXTRA_FORCE_NOT_INTERNAL_APPS = "force_not_internal_apps";
@@ -1496,6 +1497,8 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
             NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.currentUserPremiumStatusChanged);
             NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.chatSwithcedToForum);
             NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.storiesEnabledUpdate);
+            // Na: [ExternalStickerCache] remove observers
+            ExternalStickerCacheHelper.removeNotificationObservers(currentAccount);
         }
         currentAccount = UserConfig.selectedAccount;
         NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.appDidLogout);
@@ -1518,6 +1521,8 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
         NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.currentUserPremiumStatusChanged);
         NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.chatSwithcedToForum);
         NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.storiesEnabledUpdate);
+        // Na: [ExternalStickerCache] add observers
+        ExternalStickerCacheHelper.addNotificationObservers(currentAccount);
     }
 
     private void checkLayout() {

--- a/TMessagesProj/src/main/java/org/telegram/ui/StickersActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/StickersActivity.java
@@ -1710,6 +1710,7 @@ public class StickersActivity extends BaseFragment implements NotificationCenter
                         StickerSetCell cell = (StickerSetCell) v.getParent();
                         TLRPC.TL_messages_stickerSet stickerSet = cell.getStickersSet();
                         ItemOptions options = ItemOptions.makeOptions(StickersActivity.this, cell);
+                        options.add(R.drawable.msg_archive, LocaleController.getString("StickersHide", R.string.StickersHide), () -> processSelectionOption(MENU_ARCHIVE, stickerSet));
                         if (stickerSet.set.official) {
                             options.add(R.drawable.msg_reorder, LocaleController.getString("StickersReorder", R.string.StickersReorder), () -> processSelectionOption(4, stickerSet));
                         } else {

--- a/TMessagesProj/src/main/java/org/telegram/ui/StickersActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/StickersActivity.java
@@ -129,6 +129,8 @@ import tw.nekomimi.nekogram.utils.FileUtil;
 import tw.nekomimi.nekogram.utils.ShareUtil;
 import tw.nekomimi.nekogram.utils.StickersUtil;
 import tw.nekomimi.nekogram.utils.UIUtil;
+import xyz.nextalone.nagram.NaConfig;
+import xyz.nextalone.nagram.helper.ExternalStickerCacheHelper;
 
 public class StickersActivity extends BaseFragment implements NotificationCenter.NotificationCenterDelegate {
 
@@ -1708,7 +1710,6 @@ public class StickersActivity extends BaseFragment implements NotificationCenter
                         StickerSetCell cell = (StickerSetCell) v.getParent();
                         TLRPC.TL_messages_stickerSet stickerSet = cell.getStickersSet();
                         ItemOptions options = ItemOptions.makeOptions(StickersActivity.this, cell);
-                        options.add(R.drawable.msg_archive, LocaleController.getString("StickersHide", R.string.StickersHide), () -> processSelectionOption(MENU_ARCHIVE, stickerSet));
                         if (stickerSet.set.official) {
                             options.add(R.drawable.msg_reorder, LocaleController.getString("StickersReorder", R.string.StickersReorder), () -> processSelectionOption(4, stickerSet));
                         } else {
@@ -1722,6 +1723,10 @@ public class StickersActivity extends BaseFragment implements NotificationCenter
                             options.add(R.drawable.msg_reorder, LocaleController.getString("StickersReorder", R.string.StickersReorder), () -> processSelectionOption(4, stickerSet));
                             options.add(R.drawable.msg_share, LocaleController.getString("StickersShare", R.string.StickersShare), () -> processSelectionOption(2, stickerSet));
                             options.add(R.drawable.msg_delete, LocaleController.getString("StickersRemove", R.string.StickersRemove), true, () -> processSelectionOption(MENU_DELETE, stickerSet));
+                            if (!NaConfig.INSTANCE.getExternalStickerCache().String().isBlank()) {
+                                options.add(R.drawable.menu_views_reposts, LocaleController.getString(R.string.ExternalStickerCacheRefresh), () -> ExternalStickerCacheHelper.refreshCacheFiles(stickerSet));
+                                options.add(R.drawable.msg_delete, LocaleController.getString(R.string.ExternalStickerCacheDelete), () -> ExternalStickerCacheHelper.deleteCacheFiles(stickerSet));
+                            }
                         }
                         options.setMinWidth(190);
                         options.show();

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/config/cell/ConfigCellText.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/config/cell/ConfigCellText.java
@@ -9,6 +9,8 @@ public class ConfigCellText extends AbstractConfigCell implements WithKey, WithO
     private final String key;
     private final String value;
     private final Runnable onClick;
+    private boolean enabled = true;
+    private TextSettingsCell cell;
 
     public ConfigCellText(String key, String customValue, Runnable onClick) {
         this.key = key;
@@ -29,16 +31,24 @@ public class ConfigCellText extends AbstractConfigCell implements WithKey, WithO
     }
 
     public boolean isEnabled() {
-        return true;
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        if (this.cell != null) this.cell.setEnabled(this.enabled);
     }
 
     public void onBindViewHolder(RecyclerView.ViewHolder holder) {
         TextSettingsCell cell = (TextSettingsCell) holder.itemView;
+        this.cell = cell;
         String title = LocaleController.getString(key);
         cell.setTextAndValue(title, value, cellGroup.needSetDivider(this));
+        cell.setEnabled(enabled);
     }
 
     public void onClick() {
+        if (!enabled) return;
         if (onClick != null) {
             try {
                 onClick.run();

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/config/cell/ConfigCellText.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/config/cell/ConfigCellText.java
@@ -1,0 +1,48 @@
+package tw.nekomimi.nekogram.config.cell;
+
+import androidx.recyclerview.widget.RecyclerView;
+import org.telegram.messenger.LocaleController;
+import org.telegram.ui.Cells.TextSettingsCell;
+import tw.nekomimi.nekogram.config.CellGroup;
+
+public class ConfigCellText extends AbstractConfigCell implements WithKey, WithOnClick {
+    private final String key;
+    private final String value;
+    private final Runnable onClick;
+
+    public ConfigCellText(String key, String customValue, Runnable onClick) {
+        this.key = key;
+        this.value = (customValue == null) ? "" : customValue;
+        this.onClick = onClick;
+    }
+
+    public ConfigCellText(String key, Runnable onClick) {
+        this(key, null, onClick);
+    }
+
+    public int getType() {
+        return CellGroup.ITEM_TYPE_TEXT_SETTINGS_CELL;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public void onBindViewHolder(RecyclerView.ViewHolder holder) {
+        TextSettingsCell cell = (TextSettingsCell) holder.itemView;
+        String title = LocaleController.getString(key);
+        cell.setTextAndValue(title, value, cellGroup.needSetDivider(this));
+    }
+
+    public void onClick() {
+        if (onClick != null) {
+            try {
+                onClick.run();
+            } catch (Exception ignored) {}
+        }
+    }
+}

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/config/cell/WithKey.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/config/cell/WithKey.java
@@ -1,0 +1,5 @@
+package tw.nekomimi.nekogram.config.cell;
+
+public interface WithKey {
+    String getKey();
+}

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/config/cell/WithOnClick.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/config/cell/WithOnClick.java
@@ -1,0 +1,5 @@
+package tw.nekomimi.nekogram.config.cell;
+
+public interface WithOnClick {
+    void onClick();
+}

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/BaseNekoXSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/BaseNekoXSettingsActivity.java
@@ -18,13 +18,7 @@ import java.util.Locale;
 
 import tw.nekomimi.nekogram.config.CellGroup;
 import tw.nekomimi.nekogram.config.ConfigItem;
-import tw.nekomimi.nekogram.config.cell.AbstractConfigCell;
-import tw.nekomimi.nekogram.config.cell.ConfigCellAutoTextCheck;
-import tw.nekomimi.nekogram.config.cell.ConfigCellCustom;
-import tw.nekomimi.nekogram.config.cell.ConfigCellSelectBox;
-import tw.nekomimi.nekogram.config.cell.ConfigCellTextCheck;
-import tw.nekomimi.nekogram.config.cell.ConfigCellTextDetail;
-import tw.nekomimi.nekogram.config.cell.ConfigCellTextInput;
+import tw.nekomimi.nekogram.config.cell.*;
 
 public class BaseNekoXSettingsActivity extends BaseFragment {
     protected BlurredRecyclerView listView;
@@ -79,7 +73,9 @@ public class BaseNekoXSettingsActivity extends BaseFragment {
     }
 
     protected String getRowKey(AbstractConfigCell row) {
-        if (row instanceof ConfigCellTextCheck) {
+        if (row instanceof WithKey) {
+            return ((WithKey) row).getKey();
+        } else if (row instanceof ConfigCellTextCheck) {
             return ((ConfigCellTextCheck) row).getKey();
         } else if (row instanceof ConfigCellSelectBox) {
             return ((ConfigCellSelectBox) row).getKey();

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoExperimentalSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoExperimentalSettingsActivity.java
@@ -105,6 +105,7 @@ public class NekoExperimentalSettingsActivity extends BaseNekoXSettingsActivity 
     private final AbstractConfigCell externalStickerCacheRow = cellGroup.appendCell(new ConfigCellAutoTextCheck(
             NaConfig.INSTANCE.getExternalStickerCache(), LocaleController.getString(R.string.ExternalStickerCacheHint), this::onExternalStickerCacheButtonClick));
     private final AbstractConfigCell externalStickerCacheAutoSyncRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getExternalStickerCacheAutoRefresh(), LocaleController.getString(R.string.ExternalStickerCacheAutoRefreshHint)));
+    private final AbstractConfigCell externalStickerCacheDirNameTypeRow = cellGroup.appendCell(new ConfigCellSelectBox(null, NaConfig.INSTANCE.getExternalStickerCacheDirNameType(), new String[]{ "Short name", "ID" }, null));
     private final AbstractConfigCell externalStickerCacheSyncAllRow = cellGroup.appendCell(new ConfigCellText("ExternalStickerCacheRefreshAll", ExternalStickerCacheHelper::syncAllCaches));
     private final AbstractConfigCell externalStickerCacheDeleteAllRow = cellGroup.appendCell(new ConfigCellText("ExternalStickerCacheDeleteAll", ExternalStickerCacheHelper::deleteAllCaches));
     private final AbstractConfigCell divider2 = cellGroup.appendCell(new ConfigCellDivider());
@@ -115,7 +116,6 @@ public class NekoExperimentalSettingsActivity extends BaseNekoXSettingsActivity 
     private static final int INTENT_PICK_EXTERNAL_STICKER_DIRECTORY = 514;
 
     private void setExternalStickerCacheCellsEnabled(boolean enabled) {
-        ((ConfigCellTextCheck) externalStickerCacheAutoSyncRow).setEnabled(enabled);
         ((ConfigCellText) externalStickerCacheSyncAllRow).setEnabled(enabled);
         ((ConfigCellText) externalStickerCacheDeleteAllRow).setEnabled(enabled);
     }

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoExperimentalSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoExperimentalSettingsActivity.java
@@ -160,6 +160,15 @@ public class NekoExperimentalSettingsActivity extends BaseNekoXSettingsActivity 
 
         refreshExternalStickerStorageState(); // Cell (externalStickerCacheRow): Refresh state
 
+        // ExternalStickerCache: Additional options
+        if (!NaConfig.INSTANCE.getExternalStickerCache().String().isEmpty()) {
+            cellGroup.appendCell(new ConfigCellHeader(LocaleController.getString(R.string.ExternalStickerCache)));
+            cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getExternalStickerCacheAutoRefresh(), LocaleController.getString(R.string.ExternalStickerCacheAutoRefreshHint)));
+            cellGroup.appendCell(new ConfigCellText("ExternalStickerCacheRefreshAll", ExternalStickerCacheHelper::syncAllCaches));
+            cellGroup.appendCell(new ConfigCellText("ExternalStickerCacheDeleteAll", ExternalStickerCacheHelper::deleteAllCaches));
+            cellGroup.appendCell(new ConfigCellDivider());
+        }
+
         listAdapter = new ListAdapter(context);
 
         fragmentView = new FrameLayout(context);
@@ -179,6 +188,8 @@ public class NekoExperimentalSettingsActivity extends BaseNekoXSettingsActivity 
                 ((ConfigCellTextCheck) a).onClick((TextCheckCell) view);
             } else if (a instanceof ConfigCellSelectBox) {
                 ((ConfigCellSelectBox) a).onClick(view);
+            } else if (a instanceof WithOnClick) {
+                ((WithOnClick) a).onClick();
             } else if (a instanceof ConfigCellTextInput) {
                 ((ConfigCellTextInput) a).onClick();
             } else if (a instanceof ConfigCellAutoTextCheck) {

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -494,6 +494,12 @@ object NaConfig {
             ConfigItem.configTypeBool,
             false
         )
+    val externalStickerCacheDirNameType =
+        addConfig(
+            "ExternalStickerCacheDirNameType",
+            ConfigItem.configTypeInt,
+            0
+        )
 
     private fun addConfig(
         k: String,

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -488,6 +488,12 @@ object NaConfig {
     var externalStickerCacheUri: Uri?
         get() = externalStickerCache.String().let { if (it.isBlank()) return null else return Uri.parse(it) }
         set(value) = externalStickerCache.setConfigString(value.toString())
+    val externalStickerCacheAutoRefresh =
+        addConfig(
+            "ExternalStickerCacheAutoRefresh",
+            ConfigItem.configTypeBool,
+            false
+        )
 
     private fun addConfig(
         k: String,

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/helper/ExternalStickerCacheHelper.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/helper/ExternalStickerCacheHelper.kt
@@ -61,7 +61,6 @@ object ExternalStickerCacheHelper {
     private var cacheAgain = false
 
     @JvmStatic
-    @JvmOverloads
     fun cacheStickers(isAutoSync: Boolean = true) {
         if (isAutoSync && !NaConfig.externalStickerCacheAutoRefresh.Bool()) return
         if (caching) {
@@ -69,6 +68,10 @@ object ExternalStickerCacheHelper {
             return
         }
         if (NaConfig.externalStickerCache.String().isEmpty()) return
+        cacheStickers0(isAutoSync)
+    }
+
+    private fun cacheStickers0(isAutoSync: Boolean) {
         async {
             caching = true
             val stickerSets = MediaDataController.getInstance(UserConfig.selectedAccount).getStickerSets(MediaDataController.TYPE_IMAGE)
@@ -140,7 +143,7 @@ object ExternalStickerCacheHelper {
             if (cacheAgain) {
                 delay(30000)
                 cacheAgain = false
-                cacheStickers()
+                cacheStickers0(true)
             } else {
                 caching = false
             }

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/helper/ExternalStickerCacheHelper.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/helper/ExternalStickerCacheHelper.kt
@@ -11,6 +11,8 @@ import org.telegram.messenger.AndroidUtilities
 import org.telegram.messenger.ApplicationLoader
 import org.telegram.messenger.LocaleController
 import org.telegram.messenger.MediaDataController
+import org.telegram.messenger.NotificationCenter
+import org.telegram.messenger.NotificationCenter.NotificationCenterDelegate
 import org.telegram.messenger.R
 import org.telegram.messenger.UserConfig
 import org.telegram.tgnet.TLRPC.TL_messages_stickerSet
@@ -242,6 +244,28 @@ object ExternalStickerCacheHelper {
             } catch (e: Exception) {
                 logException(e, "deleting all caches")
             }
+        }
+    }
+
+    private val observer = NotificationCenterDelegate { _, _, _ -> cacheStickers(true) }
+    private val notificationIdList = listOf(
+        NotificationCenter.stickersDidLoad,
+        NotificationCenter.diceStickersDidLoad,
+        NotificationCenter.featuredStickersDidLoad,
+        NotificationCenter.stickersImportComplete,
+    )
+
+    @JvmStatic
+    fun addNotificationObservers(currentAccount: Int) {
+        NotificationCenter.getInstance(currentAccount).apply {
+            notificationIdList.forEach { addObserver(observer, it) }
+        }
+    }
+
+    @JvmStatic
+    fun removeNotificationObservers(currentAccount: Int) {
+        NotificationCenter.getInstance(currentAccount).apply {
+            notificationIdList.forEach { removeObserver(observer, it) }
         }
     }
 

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
@@ -99,4 +99,10 @@
     <string name="ExternalStickerCacheHint">用于与其他应用共享贴纸包 (点击选择存储位置)</string>
     <string name="ExternalStickerCacheRefresh">刷新外部缓存</string>
     <string name="ExternalStickerCacheDelete">删除外部缓存</string>
+    <string name="ExternalStickerCacheWaitSync">正在等待缓存同步完成</string>
+    <string name="ExternalStickerCacheSyncNotFinished">缓存同步已经在运行了</string>
+    <string name="ExternalStickerCacheAutoRefresh">自动同步</string>
+    <string name="ExternalStickerCacheAutoRefreshHint">在有贴纸事件时自动同步所有缓存</string>
+    <string name="ExternalStickerCacheRefreshAll">同步所有缓存</string>
+    <string name="ExternalStickerCacheDeleteAll">删除所有缓存</string>
 </resources>

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
@@ -105,5 +105,6 @@
     <string name="ExternalStickerCacheAutoRefreshHint">在有贴纸事件时自动同步所有缓存</string>
     <string name="ExternalStickerCacheRefreshAll">同步所有缓存</string>
     <string name="ExternalStickerCacheDeleteAll">删除所有缓存</string>
+    <string name="ExternalStickerCacheDirNameType">目录命名方式</string>
     <string name="ProviderTranSmartTranslate">腾讯交互翻译</string>
 </resources>

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
@@ -95,7 +95,7 @@
     <string name="DisableCustomWallpaperUser">禁用私聊的自定义背景</string>
     <string name="DisableCustomWallpaperChannel">禁用频道的自定义背景</string>
     <string name="CopyPhotoAsSticker">复制图片但是贴纸</string>
-    <string name="ExternalStickerCache">在外部存储缓存贴纸文件</string>
+    <string name="ExternalStickerCache">外部贴纸缓存</string>
     <string name="ExternalStickerCacheHint">用于与其他应用共享贴纸包 (点击选择存储位置)</string>
     <string name="ExternalStickerCacheRefresh">刷新外部缓存</string>
     <string name="ExternalStickerCacheDelete">删除外部缓存</string>

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -108,5 +108,6 @@
     <string name="ExternalStickerCacheAutoRefreshHint">Automatically sync all caches after receiving sticker events</string>
     <string name="ExternalStickerCacheRefreshAll">Sync all caches</string>
     <string name="ExternalStickerCacheDeleteAll">Delete all caches</string>
+    <string name="ExternalStickerCacheDirNameType">Directory naming</string>
     <string name="ProviderTranSmartTranslate">TranSmart Translator</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -102,4 +102,10 @@
     <string name="ExternalStickerCacheHint">For sharing sticker packs with other apps. Click to pick storage location.</string>
     <string name="ExternalStickerCacheRefresh">Refresh External Cache</string>
     <string name="ExternalStickerCacheDelete">Delete External Cache</string>
+    <string name="ExternalStickerCacheWaitSync">Waiting for cache sync to finish</string>
+    <string name="ExternalStickerCacheSyncNotFinished">Cache sync is already running</string>
+    <string name="ExternalStickerCacheAutoRefresh">Automatic sync</string>
+    <string name="ExternalStickerCacheAutoRefreshHint">Automatically sync all caches after receiving sticker events</string>
+    <string name="ExternalStickerCacheRefreshAll">Sync all caches</string>
+    <string name="ExternalStickerCacheDeleteAll">Delete all caches</string>
 </resources>


### PR DESCRIPTION
add: 自动同步开关
add: 手动一键同步和删除所有缓存的按钮
add: StickersActivity 中的刷新和删除菜单项
add: 支持使用 short name 作为目录名
improve: 使用 Telegram 的 NotificationCenter 来触发自动同步
improve: 为设置项添加独立分组
improve: 改了一下设置项的中文名让它更好看
improve: 自动创建 .nomedia 以避免相册惨剧
fix: `ExternalStickerCacheHelper.caching` 值变为 true 后不会自动改回 false