### PR TITLE
feat: disable click command to send

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -9159,6 +9159,7 @@ public class ChatActivityEnterView extends BlurredFrameLayout implements Notific
         if (command == null || getVisibility() != VISIBLE || messageEditText == null) {
             return;
         }
+        ifLongPress:
         if (longPress) {
             String text = messageEditText.getText().toString();
             TLRPC.User user = messageObject != null && DialogObject.isChatDialog(dialog_id) ? accountInstance.getMessagesController().getUser(messageObject.messageOwner.from_id.user_id) : null;
@@ -9178,6 +9179,10 @@ public class ChatActivityEnterView extends BlurredFrameLayout implements Notific
                 openKeyboard();
             }
         } else {
+            // Na: DisableClickCommandToSend
+            boolean disableClickCommandToSend = NaConfig.INSTANCE.getDisableClickCommandToSend().Bool();
+            if (disableClickCommandToSend) break ifLongPress;
+
             if (slowModeTimer > 0 && !isInScheduleMode()) {
                 if (delegate != null) {
                     delegate.onUpdateSlowModeButton(slowModeButton, true, slowModeButton.getText());

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -9159,7 +9159,6 @@ public class ChatActivityEnterView extends BlurredFrameLayout implements Notific
         if (command == null || getVisibility() != VISIBLE || messageEditText == null) {
             return;
         }
-        ifLongPress:
         if (longPress) {
             String text = messageEditText.getText().toString();
             TLRPC.User user = messageObject != null && DialogObject.isChatDialog(dialog_id) ? accountInstance.getMessagesController().getUser(messageObject.messageOwner.from_id.user_id) : null;
@@ -9180,8 +9179,9 @@ public class ChatActivityEnterView extends BlurredFrameLayout implements Notific
             }
         } else {
             // Na: DisableClickCommandToSend
-            boolean disableClickCommandToSend = NaConfig.INSTANCE.getDisableClickCommandToSend().Bool();
-            if (disableClickCommandToSend) break ifLongPress;
+            if (NaConfig.INSTANCE.getDisableClickCommandToSend().Bool()) {
+                return;
+            }
 
             if (slowModeTimer > 0 && !isInScheduleMode()) {
                 if (delegate != null) {

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
@@ -153,6 +153,7 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
     private final AbstractConfigCell hideBotButtonInInputFieldRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getHideBotButtonInInputField()));
     private final AbstractConfigCell doNotUnarchiveBySwipeRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getDoNotUnarchiveBySwipe()));
     private final AbstractConfigCell disableMarkdownRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getDisableMarkdown()));
+    private final AbstractConfigCell disableClickCommandToSendRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getDisableClickCommandToSend(), LocaleController.getString(R.string.DisableClickCommandToSendHint)));
     private final AbstractConfigCell dividerInteractions = cellGroup.appendCell(new ConfigCellDivider());
 
     // Sticker

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -518,6 +518,12 @@ object NaConfig {
             ConfigItem.configTypeBool,
             false
         )
+    val disableClickCommandToSend =
+        addConfig(
+            "DisableClickCommandToSend",
+            ConfigItem.configTypeBool,
+            false
+        )
 
     private fun addConfig(
         k: String,

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
@@ -120,4 +120,6 @@
     <string name="TipsInfo">要关注我们的功能介绍频道吗 ？</string>
     <string name="TipsChannel">功能介绍频道</string>
     <string name="ShowSmallGIF">GIF 显示得更小</string>
+    <string name="DisableClickCommandToSend">禁用点击指令文本发送</string>
+    <string name="DisableClickCommandToSendHint">妈妈再也不用担心我会误触啦</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -120,4 +120,6 @@
     <string name="TipsInfo">Want to follow our features tips channel?</string>
     <string name="TipsChannel">Features Tips Channel</string>
     <string name="ShowSmallGIF">Show Small Gif</string>
+    <string name="DisableClickCommandToSend">Disable click command text to send</string>
+    <string name="DisableClickCommandToSendHint">To prevent accidental touch</string>
 </resources>


### PR DESCRIPTION
An option to disable click command text to send the command (to prevent accidental touch).