### PR TITLE
fix: message statistic page header cell layout

### DIFF
--- a/TMessagesProj/src/main/java/androidx/recyclerview/widget/ItemTouchHelper.java
+++ b/TMessagesProj/src/main/java/androidx/recyclerview/widget/ItemTouchHelper.java
@@ -40,11 +40,13 @@ import androidx.recyclerview.widget.RecyclerView.OnItemTouchListener;
 import androidx.recyclerview.widget.RecyclerView.ViewHolder;
 
 import org.telegram.messenger.AndroidUtilities;
+import org.telegram.ui.Cells.DialogCell;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import tw.nekomimi.nekogram.NekoConfig;
+import xyz.nextalone.nagram.NaConfig;
 
 /**
  * This is a utility class to add swipe to dismiss and drag & drop support to RecyclerView.
@@ -1257,6 +1259,11 @@ public class ItemTouchHelper extends RecyclerView.ItemDecoration
     }
 
     public int checkHorizontalSwipe(ViewHolder viewHolder, int flags) {
+        if (viewHolder != null && viewHolder.itemView instanceof DialogCell) {
+            if (((DialogCell) viewHolder.itemView).getCurrentDialogFolderId() == 0 && NaConfig.INSTANCE.getDoNotUnarchiveBySwipe().Bool()) {
+                return 0;
+            }
+        }
         if ((flags & (LEFT | RIGHT)) != 0) {
             final int dirFlag = mDx > 0 ? RIGHT : LEFT;
             if (mVelocityTracker != null && mActivePointerId > -1) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -29332,7 +29332,7 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                         }
                         if (canViewStats) {
                             items.add(LocaleController.getString("ViewStats", R.string.ViewStats));
-                            options.add(28);
+                            options.add(OPTION_STATISTICS);
                             icons.add(R.drawable.msg_stats);
                         }
                         if (allowUnpin) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
@@ -2671,12 +2671,6 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
 
         @Override
         public float getSwipeThreshold(RecyclerView.ViewHolder viewHolder) {
-            if (viewHolder != null && viewHolder.itemView instanceof DialogCell) {
-                if (((DialogCell) viewHolder.itemView).getCurrentDialogFolderId() == 0
-                && NaConfig.INSTANCE.getDoNotUnarchiveBySwipe().Bool()) {
-                    return 1.0f;
-                }
-            }
             return 0.45f;
         }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/MessageStatisticActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/MessageStatisticActivity.java
@@ -1004,11 +1004,11 @@ public class MessageStatisticActivity extends BaseFragment implements Notificati
                     HeaderCell headerCell = (HeaderCell) holder.itemView;
                     if (position == overviewHeaderRow) {
                         headerCell.setTopMargin(9);
-                        headerCell.setPadding(0, 0, 0, AndroidUtilities.dp(8));
+                        headerCell.setPadding(AndroidUtilities.dp(16), 0, AndroidUtilities.dp(16), AndroidUtilities.dp(8));
                         headerCell.setText(LocaleController.formatString("StatisticOverview", R.string.StatisticOverview));
                     } else {
                         headerCell.setTopMargin(11);
-                        headerCell.setPadding(0, 0, 0, 0);
+                        headerCell.setPadding(AndroidUtilities.dp(16), 0, AndroidUtilities.dp(16), 0);
                         headerCell.setText(LocaleController.formatString("PublicShares", R.string.PublicShares));
                     }
                     break;


### PR DESCRIPTION
修复消息统计数据页面标题布局

![photo_2024-07-07_19-05-31](https://github.com/NextAlone/Nagram/assets/10793522/f1186cde-514b-4ca7-8db6-9e2fcbf63bc1)

官方版本没这个问题，应该是这个提交导致的 dd08362cc6163094fb7f28366a6629ca5d16c958

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a layout issue on the message statistics page by adjusting the padding of header cells to ensure proper alignment.

- **Bug Fixes**:
    - Fixed the layout of the header cells on the message statistics page by adjusting padding values.

<!-- Generated by sourcery-ai[bot]: end summary -->