### PR TITLE
fix: local build on macOS or other platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,20 +104,26 @@ MTProto protocol manuals: <https://core.telegram.org/mtproto>
 
 Environment:
 
-- A Linux distribution based on Debian (e.g. Ubuntu)
+- Linux distribution based on Debian or Arch Linux, or macOS
 
-- Native tools: `gcc` `go` `make` `cmake` `ninja` `yasm`
+- Native tools: `gcc` `go` `make` `cmake` `ninja` `yasm` `meson` `pkgconf`
   
   ```shell
+  # for Debian based distribution
   sudo apt install gcc golang make cmake ninja-build yasm
+  # for Arch Linux based distribution
+  sudo pacman -S base-devel go ninja cmake yasm meson
+  # for macOS
+  xcode-select --install # install developer tools (will open confirm dialog)
+  brew install go cmake ninja yasm meson pkgconf # install other tools by homebrew
   ```
-- Android SDK: `build-tools;33.0.0` `platforms;android-33` `ndk;21.4.7075529` `cmake;3.18.1` (the default location is **$HOME/Android/SDK**, otherwise you need to specify **$ANDROID_HOME** for it)
+- Android SDK: `build-tools;33.0.0` `platforms;android-33` `ndk;21.4.7075529` `cmake;3.18.1` `cmake;3.22.1` (the default location is **$HOME/Android/SDK**, otherwise you need to specify **$ANDROID_HOME** for it)
 
-  It is recommended to use [Android Studio](https://developer.android.com/studio) to install, but you can also use `sdkmanager`:
+  It is recommended to use [Android Studio](https://developer.android.com/studio) to install, but you can also use `sdkmanager` command on distributions based on Debian:
 
   ```shell
   sudo apt install sdkmanager
-  sdkmanager --sdk_root $HOME/Android/SDK --install "build-tools;33.0.0" "platforms;android-33" "ndk;21.4.7075529" "cmake;3.18.1"
+  sdkmanager --sdk_root $HOME/Android/SDK --install "build-tools;33.0.0" "platforms;android-33" "ndk;21.4.7075529" "cmake;3.18.1" "cmake;3.22.1"
   ```
 
 Build: 
@@ -147,7 +153,7 @@ Build:
 7. Build with Gradle:
 
    ```shell
-   ./gradlew assembleMini<Debug/Release/ReleaseNoGcm>
+   ./gradlew assemble<Release/Debug>
    ```
 
 8. Generate `TMessagesProj/jni/integrity/genuine.h` - https://github.com/brevent/genuine

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -183,7 +183,7 @@ android {
             jniDebuggable true
             multiDexEnabled true
             zipAlignEnabled true
-            signingConfig signingConfigs.release
+//            signingConfig signingConfigs.release
         }
 
         release {

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -183,7 +183,7 @@ android {
             jniDebuggable true
             multiDexEnabled true
             zipAlignEnabled true
-//            signingConfig signingConfigs.release
+            signingConfig signingConfigs.release
         }
 
         release {

--- a/TMessagesProj/jni/build_dav1d_clang.sh
+++ b/TMessagesProj/jni/build_dav1d_clang.sh
@@ -95,7 +95,7 @@ checkPreRequisites
 cd dav1d
 
 ## common
-LLVM_PREFIX="${NDK}/toolchains/llvm/prebuilt/linux-x86_64"
+LLVM_PREFIX="${NDK}/toolchains/llvm/prebuilt/${BUILD_PLATFORM}"
 LLVM_BIN="${LLVM_PREFIX}/bin"
 PREFIX_D=$(realpath .)
 VERSION="4.9"

--- a/TMessagesProj/jni/build_ffmpeg_clang.sh
+++ b/TMessagesProj/jni/build_ffmpeg_clang.sh
@@ -161,7 +161,7 @@ checkPreRequisites
 cd ffmpeg
 
 ## common
-LLVM_PREFIX="${NDK}/toolchains/llvm/prebuilt/linux-x86_64"
+LLVM_PREFIX="${NDK}/toolchains/llvm/prebuilt/${BUILD_PLATFORM}"
 LLVM_BIN="${LLVM_PREFIX}/bin"
 PREFIX_D=$(realpath ..)
 VERSION="4.9"

--- a/TMessagesProj/jni/build_libvpx_clang.sh
+++ b/TMessagesProj/jni/build_libvpx_clang.sh
@@ -115,7 +115,7 @@ checkPreRequisites
 cd libvpx
 
 ## common
-LLVM_PREFIX="${NDK}/toolchains/llvm/prebuilt/linux-x86_64"
+LLVM_PREFIX="${NDK}/toolchains/llvm/prebuilt/${BUILD_PLATFORM}"
 LLVM_BIN="${LLVM_PREFIX}/bin"
 VERSION="4.9"
 ANDROID_API=21

--- a/TMessagesProj/jni/patch_ffmpeg.sh
+++ b/TMessagesProj/jni/patch_ffmpeg.sh
@@ -6,7 +6,7 @@ patch -d ffmpeg -p1 < patches/ffmpeg/0001-compilation-magic.patch
 patch -d ffmpeg -p1 < patches/ffmpeg/0002-compilation-magic-2.patch
 
 function cp {
-	install -D $@
+	install "$1" "$2"
 }
 
 cp ffmpeg/libavformat/dv.h ffmpeg/build/arm64-v8a/include/libavformat/dv.h


### PR DESCRIPTION
Now macOS can build the app locally, but I'm not sure whether the changes will affect CI build. Most likely not.
By the way, it seems `./run libs native` is not necessary for `assembleDebug` now.

## Summary by Sourcery

Add support for building the app on macOS.

New Features:
- Enable local builds on macOS.

Enhancements:
- Simplify the Gradle build command.

Build:
- Update build instructions to include macOS and Arch Linux.