### PR TITLE
Fix thread startup during runtime shutdown

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/DispatchQueue.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/DispatchQueue.java
@@ -34,6 +34,7 @@ public class DispatchQueue extends Thread {
     public DispatchQueue(final String threadName, boolean start) {
         setName(threadName);
         if (start) {
+            setDaemon(true);
             start();
         }
     }
@@ -42,6 +43,7 @@ public class DispatchQueue extends Thread {
         this.threadPriority = priority;
         setName(threadName);
         if (start) {
+            setDaemon(true);
             start();
         }
     }


### PR DESCRIPTION
Mark DispatchQueue threads as daemon threads to prevent the "Thread starting during runtime shutdown" InternalError. This change ensures that new threads won't be started during the shutdown process, thereby allowing the application to exit cleanly.

## Summary by Sourcery

Bug Fixes:
- Prevent "Thread starting during runtime shutdown" errors by marking DispatchQueue threads as daemon threads, ensuring a clean application exit during shutdown.