### PR TITLE
Fix thread startup during runtime shutdown

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/DispatchQueue.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/DispatchQueue.java
@@ -34,6 +34,7 @@ public class DispatchQueue extends Thread {
     public DispatchQueue(final String threadName, boolean start) {
         setName(threadName);
         if (start) {
+            setDaemon(true);
             start();
         }
     }
@@ -42,6 +43,7 @@ public class DispatchQueue extends Thread {
         this.threadPriority = priority;
         setName(threadName);
         if (start) {
+            setDaemon(true);
             start();
         }
     }

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
@@ -50,7 +50,7 @@
     <string name="DisableGlobalSearch">禁用全局搜索</string>
     <string name="InputMessageId">输入消息 ID</string>
     <string name="ToTheMessage">回到消息</string>
-    <string name="HideOriginAfterTranslation">翻译隐藏后原文</string>
+    <string name="HideOriginAfterTranslation">翻译后隐藏原文</string>
     <string name="ZalgoFilter">过滤 \"Zalgo\" 符号</string>
     <string name="ZalgoFilterNotice">昵称和消息中的 \"Z̷͍͌ā̸̜l̸̞̂g̷̝͘o̶̩̓\" 符号将被过滤</string>
     <string name="CustomChannelLabel">自定义频道默认别名</string>


### PR DESCRIPTION
Set new threads as daemon threads and correct a translation in Simplified Chinese.

Bug Fixes:
- Fix thread startup during runtime shutdown by setting new threads as daemon threads.

Documentation:
- Correct the translation of "HideOriginAfterTranslation" in Simplified Chinese.