### PR TITLE
fix: UI stack overflow when using tablet devices

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -23268,8 +23268,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             }
         } else if (event.getAction() == MotionEvent.ACTION_HOVER_EXIT) {
             currentFocusedVirtualView = -1;
+            return true;
         }
-        return super.dispatchHoverEvent(event);
+        return false;
     }
 
     @Override


### PR DESCRIPTION
When using a tablet/device with a pointer, the chat interface responds to hover events indefinitely, resulting in a stack overflow

## Summary by Sourcery

Bug Fixes:
- Resolve an issue causing stack overflow when handling hover events on tablet devices with pointer input