### PR TITLE
feat: Disable contact phone number sharing prompt。

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -28602,7 +28602,7 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                 }
                 addToContactsButton.setTag(null);
                 addToContactsButton.setVisibility(View.VISIBLE);
-            } else if (showShare && !user.self) {
+            } else if (showShare && !user.self && !NaConfig.INSTANCE.getDisablePhoneSharePrompt().Bool()) {
                 createTopPanel();
                 if (topChatPanelView == null) {
                     return;

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
@@ -207,6 +207,7 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
             add(new ConfigCellTextCheck(NaConfig.INSTANCE.getDisablePremiumFavoriteEmojiTags()));
             add(new ConfigCellTextCheck(NaConfig.INSTANCE.getDisableNonPremiumChannelChatShow()));
             add(new ConfigCellTextCheck(NaConfig.INSTANCE.getDisableShortcutTagActions()));
+            add(new ConfigCellTextCheck(NaConfig.INSTANCE.getDisablePhoneSharePrompt()));
         }}));
     }));
     private final AbstractConfigCell disableSwipeToNextRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.disableSwipeToNext));

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -803,6 +803,13 @@ object NaConfig {
             12,
             false
         )
+    val disablePhoneSharePrompt =
+        addConfig(
+            "DisablePhoneSharePrompt",
+            disableTrendingFlags,
+            13,
+            false
+        )
     val disableRepeatInChannel =
         addConfig(
             "DisableRepeatInChannel",

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
@@ -178,7 +178,7 @@
     <string name="DisableFavoriteSearchEmojiTags">禁用收藏夹标签搜索栏Emoji列表</string>
     <string name="DisableFeatuerdEmojis">禁用热门Premium Emoji</string>
     <string name="DisableFeaturedStickers">禁用热门Premium Stickers</string>
-    <string name="DisableFeaturedGifs">禁用热门GIF图</string>
+    <string name="DisableFeaturedGifs">禁用热门GIF</string>
     <string name="DisablePremiumFavoriteEmojiTags">禁用Premium收藏夹Emoji标签</string>
     <string name="DisableNonPremiumChannelChatShow">禁用非Premium频道马甲显示</string>
     <string name="DisableRepeatInChannel">在频道中禁用复读</string>
@@ -186,4 +186,5 @@
     <string name="DisableDoubleTapWhenSelecting">已禁止在选择模式中使用双击</string>
     <string name="DisableActionBarButton">禁用对话导航栏按钮</string>
     <string name="DisableShortcutTagActions">禁用收藏夹快捷标签操作</string>
+    <string name="DisablePhoneSharePrompt">禁用联系人手机号分享提示</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -187,4 +187,5 @@
     <string name="DisableDoubleTapWhenSelecting">Double tap is disabled when selecting</string>\
     <string name="DisableActionBarButton">Disable Action Bar Button</string>
     <string name="DisableShortcutTagActions">Disable Favorite Shortcut Tag Actions</string>
+    <string name="DisablePhoneSharePrompt">Disable contact phone number sharing prompt</string>
 </resources>


### PR DESCRIPTION
## Summary by Sourcery

Add an option to disable the contact phone number sharing prompt in the Telegram client

New Features:
- Introduce a new configuration option to prevent showing the phone number sharing prompt for contacts

Enhancements:
- Add a toggle in chat settings to control phone number sharing prompt visibility