### PR TITLE
Pangu should work at editing messages too

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -7983,8 +7983,15 @@ public class ChatActivityEnterView extends BlurredFrameLayout implements Notific
         }
         ArrayList<TLRPC.MessageEntity> entities = MediaDataController.getInstance(currentAccount).getEntities(message, supportsSendingNewEntities());
         if (!TextUtils.equals(message[0], editingMessageObject.messageText) || entities != null && !entities.isEmpty() || !editingMessageObject.messageOwner.entities.isEmpty() || editingMessageObject.messageOwner.media instanceof TLRPC.TL_messageMediaWebPage) {
-            editingMessageObject.editingMessage = withMarkdown ? message[0] : messageEditText.getText().toString();
+            editingMessageObject.editingMessage = withMarkdown ? message[0].toString() : messageEditText.getText().toString();
             editingMessageObject.editingMessageEntities = withMarkdown ? entities : new ArrayList<>();
+
+            // Apply Pangu formatting for message editing if enabled
+            if (!editingMessageObject.isForwarded() && NaConfig.INSTANCE.getEnablePanguOnSending().Bool()) {
+                var pair = StringUtils.spacingText(editingMessageObject.editingMessage.toString(), editingMessageObject.editingMessageEntities);
+                editingMessageObject.editingMessage = pair.getFirst();
+                editingMessageObject.editingMessageEntities = pair.getSecond();
+            }
             editingMessageObject.editingMessageSearchWebPage = messageWebPageSearch;
             if (parentFragment != null && parentFragment.getCurrentChat() != null && (editingMessageObject.type == MessageObject.TYPE_TEXT || editingMessageObject.type == MessageObject.TYPE_EMOJIS) && !ChatObject.canSendEmbed(parentFragment.getCurrentChat())) {
                 editingMessageObject.editingMessageSearchWebPage = false;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -7983,7 +7983,7 @@ public class ChatActivityEnterView extends BlurredFrameLayout implements Notific
         }
         ArrayList<TLRPC.MessageEntity> entities = MediaDataController.getInstance(currentAccount).getEntities(message, supportsSendingNewEntities());
         if (!TextUtils.equals(message[0], editingMessageObject.messageText) || entities != null && !entities.isEmpty() || !editingMessageObject.messageOwner.entities.isEmpty() || editingMessageObject.messageOwner.media instanceof TLRPC.TL_messageMediaWebPage) {
-            editingMessageObject.editingMessage = withMarkdown ? message[0].toString() : messageEditText.getText().toString();
+            editingMessageObject.editingMessage = withMarkdown ? message[0] : messageEditText.getText().toString();
             editingMessageObject.editingMessageEntities = withMarkdown ? entities : new ArrayList<>();
 
             // Apply Pangu formatting for message editing if enabled

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -7987,7 +7987,7 @@ public class ChatActivityEnterView extends BlurredFrameLayout implements Notific
             editingMessageObject.editingMessageEntities = withMarkdown ? entities : new ArrayList<>();
 
             // Apply Pangu formatting for message editing if enabled
-            if (!editingMessageObject.isForwarded() && NaConfig.INSTANCE.getEnablePanguOnSending().Bool()) {
+            if (!editingMessageObject.isForwarded() && NaConfig.INSTANCE.getEnablePanguOnEditing().Bool()) {
                 var pair = StringUtils.spacingText(editingMessageObject.editingMessage.toString(), editingMessageObject.editingMessageEntities);
                 editingMessageObject.editingMessage = pair.getFirst();
                 editingMessageObject.editingMessageEntities = pair.getSecond();

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoExperimentalSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoExperimentalSettingsActivity.java
@@ -151,6 +151,7 @@ public class NekoExperimentalSettingsActivity extends BaseNekoXSettingsActivity 
     // Pangu
     private final AbstractConfigCell header4 = cellGroup.appendCell(new ConfigCellHeader(LocaleController.getString(R.string.Pangu)));
     private final AbstractConfigCell enablePanguOnSendingRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getEnablePanguOnSending(), LocaleController.getString(R.string.PanguInfo)));
+    private final AbstractConfigCell enablePanguOnEditingRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getEnablePanguOnEditing()));
     private final AbstractConfigCell enablePanguOnReceivingRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getEnablePanguOnReceiving()));
     private final AbstractConfigCell localeToDBCRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.localeToDBC));
     private final AbstractConfigCell divider3 = cellGroup.appendCell(new ConfigCellDivider());

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -676,6 +676,12 @@ object NaConfig {
             ConfigItem.configTypeBool,
             false
         )
+    val enablePanguOnEditing =
+        addConfig(
+            "EnablePanguOnEditing",
+            ConfigItem.configTypeBool,
+            false
+        )
     val enablePanguOnReceiving =
         addConfig(
             "EnablePanguOnReceiving",

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
@@ -162,6 +162,7 @@
     <string name="LocaleToDBC">界面文本使用半角符号</string>
     <string name="EnablePanguOnReceiving">接受信息 Pangu 化</string>
     <string name="EnablePanguOnSending">发送信息 Pangu 化</string>
+    <string name="EnablePanguOnEditing">编辑信息 Pangu 化</string>
     <string name="PanguInfo">使文字更具可读性。在 CJK（中文、日文、韩文）、半宽英文、数字和符号字符之间间隔中自动插入空格</string>
     <string name="SendWithPangu">使用 Pangu 发送</string>
     <string name="SendWithoutPangu">不使用 Pangu 发送</string>

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -163,6 +163,7 @@
     <string name="Pangu" translatable="false">Pangu</string>
     <string name="EnablePanguOnReceiving">Enable Pangu on receiving</string>
     <string name="EnablePanguOnSending">Enable Pangu on sending</string>
+    <string name="EnablePanguOnEditing">Enable Pangu on editing</string>
     <string name="PanguInfo">Paranoid text spacing for good readability, to automatically insert whitespace between CJK (Chinese, Japanese, Korean), half-width English, digit and symbol characters.</string>
     <string name="SendWithPangu">Send with Pangu</string>
     <string name="SendWithoutPangu">Send without Pangu</string>


### PR DESCRIPTION
## Summary by Sourcery

Apply Pangu spacing format to messages during editing when enabled and ensure proper assignment of edited text and entities.

Enhancements:
- Use toString() for assigning the edited message text.
- Integrate Pangu formatting on message edits when not forwarded and enablePanguOnSending is enabled.