### PR TITLE
Hide Instant Camera Cell

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPhotoLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPhotoLayout.java
@@ -126,6 +126,7 @@ import androidx.core.graphics.ColorUtils;
 
 import tw.nekomimi.nekogram.NekoXConfig;
 import tw.nekomimi.nekogram.NekoConfig;
+import xyz.nextalone.nagram.NaConfig;
 
 public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayout implements NotificationCenter.NotificationCenterDelegate {
 
@@ -724,9 +725,10 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
         return arrayList;
     }
 
-    public ChatAttachAlertPhotoLayout(ChatAttachAlert alert, Context context, boolean forceDarkTheme, boolean needCamera, Theme.ResourcesProvider resourcesProvider) {
+    public ChatAttachAlertPhotoLayout(ChatAttachAlert alert, Context context, boolean forceDarkTheme, boolean needCamera_, Theme.ResourcesProvider resourcesProvider) {
         super(alert, context, resourcesProvider);
         this.forceDarkTheme = forceDarkTheme;
+        boolean needCamera = needCamera_ && !NaConfig.INSTANCE.getHideInstantCamera().Bool();
         this.needCamera = needCamera;
         NotificationCenter.getGlobalInstance().addObserver(this, NotificationCenter.albumsDidLoad);
         NotificationCenter.getGlobalInstance().addObserver(this, NotificationCenter.cameraInitied);

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
@@ -191,6 +191,7 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
     private final AbstractConfigCell hideKeyboardOnChatScrollRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.hideKeyboardOnChatScroll));
     private final AbstractConfigCell rearVideoMessagesRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.rearVideoMessages));
     private final AbstractConfigCell disableInstantCameraRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.disableInstantCamera));
+    private final AbstractConfigCell hideInstantCameraRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getHideInstantCamera()));
     private final AbstractConfigCell disableVibrationRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.disableVibration));
     private final AbstractConfigCell disableProximityEventsRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.disableProximityEvents));
     private final AbstractConfigCell disableTrendingRow = cellGroup.appendCell(new ConfigCellSelectBox("DisableTrending", null, null, () -> {

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -920,6 +920,12 @@ object NaConfig {
             ConfigItem.configTypeBool,
             false
         )
+    val hideInstantCamera =
+        addConfig(
+            "HideInstantCamera",
+            ConfigItem.configTypeBool,
+            false
+        )
 
     private fun addConfig(
         k: String,

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
@@ -212,4 +212,5 @@
     <string name="RemoveFavouriteStickersInRecentStickers">从最近使用中移除已收藏的贴纸</string>
     <string name="DisableGifts">禁用个人页面中的礼物</string>
     <string name="ShowVoteCountBeforeVote">无需投票显示投票结果</string>
+    <string name="HideInstantCamera">隐藏相机即时预览</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -213,4 +213,5 @@
     <string name="RemoveFavouriteStickersInRecentStickers">Remove favourite stickers in recent stickers</string>
     <string name="DisableGifts">Disable Gifts Tab in Profile</string>
     <string name="ShowVoteCountBeforeVote">Show vote count before voting</string>
+    <string name="HideInstantCamera">Hide instant camera</string>
 </resources>


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new 'Hide Instant Camera' setting and apply it throughout the photo attachment layout to hide the instant camera cell and preview when enabled.

New Features:
- Add hideInstantCamera configuration option to disable the instant camera cell

Enhancements:
- Conditionally wrap all instant camera display and preview logic in ChatAttachAlertPhotoLayout with the hideInstantCamera flag
- Expose a Hide Instant Camera toggle in the chat settings UI with localization support