### PR TITLE
fix: resolve issue where 'Join' button was hidden

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -10345,7 +10345,8 @@ public class ChatActivity extends BaseFragment implements
         // na: DisableChannelMuteButton
         return NaConfig.INSTANCE.getDisableChannelMuteButton().Bool() &&
                 chatMode == MODE_DEFAULT && !isReport() && currentChat != null &&
-                ChatObject.isChannel(currentChat) && currentChat.broadcast && !ChatObject.canWriteToChat(currentChat);
+                ChatObject.isChannel(currentChat) && ChatObject.isInChat(currentChat) &&
+                currentChat.broadcast && !ChatObject.canWriteToChat(currentChat);
     }
 
     @Override


### PR DESCRIPTION
# Resolve issue where 'Join' button was hidden when `DisableChannelMuteButton` is enabled

## Description

In the Nnngram client, when the `DisableChannelMuteButton` setting was enabled, the 'Join' button was also hidden along with the 'Mute/Unmute' button.

## Issues Fixed or Closed by This PR

Same as PreviousAlone/Nnngram:#85.

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] My code follows the code style of this project
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance

## Summary by Sourcery

Bug Fixes:
- Ensure the DisableChannelMuteButton setting only hides the mute/unmute control and does not hide the Join button for broadcast channels.