### PR TITLE
Fix gemini api url

### DIFF
--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
@@ -550,7 +550,7 @@ private final AbstractConfigCell defaultHlsVideoQualityRow = cellGroup.appendCel
                         apiUrl = "https://api.openai.com/v1/chat/completions";
                         break;
                     case 1: // Gemini
-                        apiUrl = "https://generativelanguage.googleapis.com/v1beta/openai/";
+                        apiUrl = "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions";
                         break;
                     case 2: // Groq
                         apiUrl = "https://api.groq.com/openai/v1/chat/completions";


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the Gemini API URL to point to the correct v1beta OpenAI-compatible chat completions endpoint.