### PR TITLE
fix: show in chat on small tablets

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -1308,6 +1308,10 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
         return mainFragmentsStack.size();
     }
 
+    public boolean isTabletFullSizeLayout() {
+        return AndroidUtilities.isTablet() && tabletFullSize;
+    }
+
     private void checkCurrentAccount() {
         if (currentAccount != UserConfig.selectedAccount) {
             NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.openBoostForUsersDialog);

--- a/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
@@ -5359,7 +5359,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
                         NotificationCenter.getInstance(currentAccount).postNotificationName(NotificationCenter.closeChats);
                     }
                     if (parentActivity instanceof LaunchActivity) {
-						LaunchActivity launchActivity = (LaunchActivity) parentActivity;
+                        LaunchActivity launchActivity = (LaunchActivity) parentActivity;
                         boolean remove = launchActivity.getMainFragmentsCount() > 1 || AndroidUtilities.isTablet();
                         launchActivity.presentFragment(new ChatActivity(args), remove, true);
                     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
@@ -5355,11 +5355,11 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
                     if (id == gallery_menu_reply) {
                         args.putInt("reply_to", currentMessageObject.getId());
                     }
-                    LaunchActivity launchActivity = parentActivity instanceof LaunchActivity ? (LaunchActivity) parentActivity : null;
-                    if (launchActivity == null || !launchActivity.isTabletFullSizeLayout()) {
+					if (!(parentActivity instanceof LaunchActivity) || !((LaunchActivity) parentActivity).isTabletFullSizeLayout()) {
                         NotificationCenter.getInstance(currentAccount).postNotificationName(NotificationCenter.closeChats);
                     }
-                    if (launchActivity != null) {
+                    if (parentActivity instanceof LaunchActivity) {
+						LaunchActivity launchActivity = (LaunchActivity) parentActivity;
                         boolean remove = launchActivity.getMainFragmentsCount() > 1 || AndroidUtilities.isTablet();
                         launchActivity.presentFragment(new ChatActivity(args), remove, true);
                     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
@@ -5355,9 +5355,11 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
                     if (id == gallery_menu_reply) {
                         args.putInt("reply_to", currentMessageObject.getId());
                     }
-                    NotificationCenter.getInstance(currentAccount).postNotificationName(NotificationCenter.closeChats);
-                    if (parentActivity instanceof LaunchActivity) {
-                        LaunchActivity launchActivity = (LaunchActivity) parentActivity;
+                    LaunchActivity launchActivity = parentActivity instanceof LaunchActivity ? (LaunchActivity) parentActivity : null;
+                    if (launchActivity == null || !launchActivity.isTabletFullSizeLayout()) {
+                        NotificationCenter.getInstance(currentAccount).postNotificationName(NotificationCenter.closeChats);
+                    }
+                    if (launchActivity != null) {
                         boolean remove = launchActivity.getMainFragmentsCount() > 1 || AndroidUtilities.isTablet();
                         launchActivity.presentFragment(new ChatActivity(args), remove, true);
                     }


### PR DESCRIPTION
Fix `Show in Chat` navigation from `PhotoViewer` on small tablets.

On small tablets using the full-size tablet layout in portrait, `Show in Chat` could close the viewer and return to the chat list instead of opening the target message.

This was caused by posting `closeChats` before presenting the target `ChatActivity`, which could close the active chat and drop the navigation during transition.

This PR avoids posting `closeChats` when `LaunchActivity` is already using the full-size tablet layout. Split-view tablet and phone layouts keep the existing behavior.

## Summary by Sourcery

Adjust chat navigation from PhotoViewer to respect tablet full-size layout and avoid unintended chat closure on small tablets.

Bug Fixes:
- Prevent `Show in Chat` from closing the current chat and returning to the chat list on small tablets in full-size tablet portrait layout.

Enhancements:
- Expose an `isTabletFullSizeLayout` helper on LaunchActivity to centralize full-size tablet layout checks.