### PR TITLE
fix: hide greetings sticker

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatGreetingsView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatGreetingsView.java
@@ -65,6 +65,7 @@ public class ChatGreetingsView extends LinearLayout {
     public BackupImageView nextStickerToSendView;
     private final Theme.ResourcesProvider resourcesProvider;
     boolean wasDraw;
+    boolean showSticker = !NekoConfig.dontSendGreetingSticker.Bool();
 
     public ChatGreetingsView(Context context, TLRPC.User user, int currentAccount, TLRPC.Document sticker, Theme.ResourcesProvider resourcesProvider) {
         super(context);
@@ -236,7 +237,7 @@ public class ChatGreetingsView extends LinearLayout {
                 }
             }
         } else {
-            addView(titleView, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT, Gravity.CENTER_HORIZONTAL, 20, 6, 20, 6));
+            addView(titleView, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT, Gravity.CENTER_HORIZONTAL, 20, showSticker ? 6 : -4, 20, 6));
             addView(descriptionView, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT, Gravity.CENTER_HORIZONTAL, 20, 6, 20, 6));
             addView(stickerContainer, LayoutHelper.createLinear(112, 112, Gravity.CENTER_HORIZONTAL, 16, 10, 16, 16));
         }
@@ -256,8 +257,6 @@ public class ChatGreetingsView extends LinearLayout {
             stickerToSendView.setImage(ImageLocation.getForDocument(sticker), createFilter(sticker), ImageLocation.getForDocument(thumb, sticker), null, 0, sticker);
         }
         stickerToSendView.setOnClickListener(v -> {
-            if (NekoConfig.dontSendGreetingSticker.Bool())
-                return;
             if (listener != null) {
                 listener.onGreetings(sticker);
             }
@@ -430,9 +429,10 @@ public class ChatGreetingsView extends LinearLayout {
         }
         stickerToSendView.setVisibility(View.VISIBLE);
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-        if (getMeasuredHeight() > MeasureSpec.getSize(heightMeasureSpec) && !preview) {
+        if ((!showSticker || getMeasuredHeight() > MeasureSpec.getSize(heightMeasureSpec)) && !preview) {
             descriptionView.setVisibility(View.GONE);
             stickerToSendView.setVisibility(View.GONE);
+            stickerContainer.setVisibility(View.GONE);
         } else {
             if (!preview) {
                 descriptionView.setVisibility(View.VISIBLE);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatGreetingsView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatGreetingsView.java
@@ -65,7 +65,6 @@ public class ChatGreetingsView extends LinearLayout {
     public BackupImageView nextStickerToSendView;
     private final Theme.ResourcesProvider resourcesProvider;
     boolean wasDraw;
-    boolean showSticker = !NekoConfig.dontSendGreetingSticker.Bool();
 
     public ChatGreetingsView(Context context, TLRPC.User user, int currentAccount, TLRPC.Document sticker, Theme.ResourcesProvider resourcesProvider) {
         super(context);
@@ -237,10 +236,14 @@ public class ChatGreetingsView extends LinearLayout {
                 }
             }
         } else {
-            addView(titleView, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT, Gravity.CENTER_HORIZONTAL, 20, showSticker ? 6 : -4, 20, 6));
+            addView(titleView, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT, Gravity.CENTER_HORIZONTAL, 20, getShowSticker() ? 6 : -4, 20, 6));
             addView(descriptionView, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT, Gravity.CENTER_HORIZONTAL, 20, 6, 20, 6));
             addView(stickerContainer, LayoutHelper.createLinear(112, 112, Gravity.CENTER_HORIZONTAL, 16, 10, 16, 16));
         }
+    }
+
+    private boolean getShowSticker() {
+        return !NekoConfig.dontSendGreetingSticker.Bool();
     }
 
     public void setSticker(TLRPC.Document sticker) {
@@ -429,7 +432,7 @@ public class ChatGreetingsView extends LinearLayout {
         }
         stickerToSendView.setVisibility(View.VISIBLE);
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-        if ((!showSticker || getMeasuredHeight() > MeasureSpec.getSize(heightMeasureSpec)) && !preview) {
+        if ((!getShowSticker() || getMeasuredHeight() > MeasureSpec.getSize(heightMeasureSpec)) && !preview) {
             descriptionView.setVisibility(View.GONE);
             stickerToSendView.setVisibility(View.GONE);
             stickerContainer.setVisibility(View.GONE);


### PR DESCRIPTION
thanks to @NagramX

taken from:
https://github.com/risin42/NagramX/commit/cef0e3fcbf33d5896377d1571940aacf9541efd5

i believe hiding the greeting sticker is better, rather than making it not function when clicked.

## Summary by Sourcery

Hide the chat greeting sticker entirely when the configuration disables sending it, instead of leaving a non-functional sticker visible.

New Features:
- Respect the dontSendGreetingSticker setting by conditionally showing or hiding the greeting sticker in chat greetings view.

Enhancements:
- Adjust chat greetings layout and visibility so that title, description, and sticker container adapt when the greeting sticker is hidden.