### PR TITLE
Two small fixes

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/VideoPlayer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/VideoPlayer.java
@@ -1002,6 +1002,9 @@ public class VideoPlayer implements Player.Listener, VideoListener, AnalyticsLis
     }
 
     public static VideoUri getQualityForPlayer(ArrayList<Quality> qualities) {
+        final Quality preferred = getDefaultSavedQuality(qualities);
+        if (preferred != null) return preferred.getDownloadUri();
+
         for (final Quality q : qualities) {
             for (final VideoUri v : q.uris) {
                 if (v.original && v.isCached())

--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
@@ -13973,8 +13973,9 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
                 }
             }
         }
-        boolean noMainTabs = NaConfig.INSTANCE.getMainTabsStyle().Int() == MainTabsStyle.DISABLE.getValue() || NaConfig.INSTANCE.getCustomDialogsMenuSettings().Bool();
-        if (getUserConfig().showCallsTab || noMainTabs) {
+        boolean needsSettingsFallback = NaConfig.INSTANCE.getMainTabsStyle().Int() == MainTabsStyle.DISABLE.getValue()
+                && !NaConfig.INSTANCE.getSidebarSettingsActivity().Bool();
+        if (NaConfig.INSTANCE.getCustomDialogsMenuSettings().Bool() || needsSettingsFallback) {
             io.add(R.drawable.msg_settings_old, getString(R.string.Settings), () -> {
                 presentFragment(new SettingsActivity());
             });

--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
@@ -13973,9 +13973,8 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
                 }
             }
         }
-        boolean needsSettingsFallback = NaConfig.INSTANCE.getMainTabsStyle().Int() == MainTabsStyle.DISABLE.getValue()
-                && !NaConfig.INSTANCE.getSidebarSettingsActivity().Bool();
-        if (NaConfig.INSTANCE.getCustomDialogsMenuSettings().Bool() || needsSettingsFallback) {
+        boolean noMainTabs = (NaConfig.INSTANCE.getMainTabsStyle().Int() == MainTabsStyle.DISABLE.getValue() || getUserConfig().showCallsTab) && !NaConfig.INSTANCE.getSidebarSettingsActivity().Bool();
+        if (NaConfig.INSTANCE.getCustomDialogsMenuSettings().Bool() || noMainTabs) {
             io.add(R.drawable.msg_settings_old, getString(R.string.Settings), () -> {
                 presentFragment(new SettingsActivity());
             });

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/config/ConfigItemKeyLinked.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/config/ConfigItemKeyLinked.java
@@ -21,11 +21,7 @@ public class ConfigItemKeyLinked extends ConfigItem {
     }
 
     public void changedFromKeyLinked(int currentConfig) {
-        if (currentConfig == 0) {
-            changed(defaultValue);
-        } else {
-            changed((currentConfig & flag) != 0);
-        }
+        changed((currentConfig & flag) != 0);
     }
 
     public boolean toggleConfigBool() {

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -1219,7 +1219,7 @@ object NaConfig {
         addConfig(
             "CustomDialogsMenu",
             ConfigItem.configTypeInt,
-            0
+            59
         )
     val customDialogsMenuTheme =
         addConfig(
@@ -1438,7 +1438,7 @@ object NaConfig {
                 }
                 if (o.type == ConfigItem.configTypeBoolLinkInt) {
                     o as ConfigItemKeyLinked
-                    o.changedFromKeyLinked(preferences.getInt(o.keyLinked.key, 0))
+                    o.changedFromKeyLinked(o.keyLinked.Int())
                 }
             }
             configLoaded =


### PR DESCRIPTION
## Summary by Sourcery

Adjust configuration linkage, dialogs settings menu behavior, and video quality selection defaults.

New Features:
- Use the saved preferred video quality when choosing the playback stream if available.

Bug Fixes:
- Align key-linked boolean configuration state with its backing integer value.
- Ensure a settings entry appears in the dialogs options when main tabs are disabled and no sidebar settings is available.

Enhancements:
- Update the default value for the custom dialogs menu configuration and rely on its accessor when syncing linked config items.