### PR TITLE
feat(settings): add reset settings

### DIFF
--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -378,7 +378,6 @@ dependencies {
     implementation "cn.hutool:hutool-core:5.8.42"
     implementation "cn.hutool:hutool-crypto:5.8.42"
     implementation 'cn.hutool:hutool-http:5.8.42'
-    implementation "com.jakewharton:process-phoenix:3.0.0"
     // openpgp
     implementation project(":openpgp-api")
 

--- a/TMessagesProj/src/main/AndroidManifest.xml
+++ b/TMessagesProj/src/main/AndroidManifest.xml
@@ -537,6 +537,11 @@
             android:taskAffinity="${applicationId}.voip_feedback"
             android:excludeFromRecents="true"
             android:theme="@style/Theme.TMessages.TransparentWithAlerts"/>
+        <activity
+            android:name="tw.nekomimi.nekogram.helpers.AppRestartHelper"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:process=":nagram"
+            android:exported="false" />
 
         <receiver
             android:name=".AutoMessageHeardReceiver"

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/UndoView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/UndoView.java
@@ -7,7 +7,6 @@ import android.animation.AnimatorListenerAdapter;
 import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
 import android.content.Context;
-import android.content.Intent;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
@@ -37,9 +36,6 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import android.widget.Toast;
-
-import com.jakewharton.processphoenix.ProcessPhoenix;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.Keep;
@@ -65,12 +61,12 @@ import org.telegram.ui.ActionBar.BaseFragment;
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.Forum.ForumUtilities;
 import org.telegram.ui.Components.Premium.boosts.BoostRepository;
-import org.telegram.ui.LaunchActivity;
 import org.telegram.ui.PaymentFormActivity;
 
 import java.util.ArrayList;
 
 import tw.nekomimi.nekogram.NekoConfig;
+import tw.nekomimi.nekogram.helpers.AppRestartHelper;
 
 @SuppressWarnings("FieldCanBeLocal")
 @Deprecated // use Bulletin instead
@@ -558,7 +554,7 @@ public class UndoView extends FrameLayout {
             undoImageView.setVisibility(GONE);
 
             undoTextView.setText(LocaleController.getString("ApplyTheme", R.string.ApplyTheme));
-            currentCancelRunnable = () -> ProcessPhoenix.triggerRebirth(getContext(), new Intent(getContext(), LaunchActivity.class));
+            currentCancelRunnable = AppRestartHelper::triggerRebirth;
 
         } else if (isTooltipAction()) {
             CharSequence infoText = "";

--- a/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
@@ -105,7 +105,6 @@ import com.android.billingclient.api.BillingFlowParams;
 import com.android.billingclient.api.ProductDetails;
 import com.android.billingclient.api.Purchase;
 import com.android.billingclient.api.QueryProductDetailsParams;
-import com.jakewharton.processphoenix.ProcessPhoenix;
 //import com.google.android.gms.auth.api.signin.GoogleSignIn;
 //import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
 //import com.google.android.gms.auth.api.signin.GoogleSignInClient;
@@ -229,6 +228,7 @@ import kotlin.Unit;
 import tw.nekomimi.nekogram.BackButtonMenuRecent;
 import tw.nekomimi.nekogram.NekoConfig;
 import tw.nekomimi.nekogram.NekoXConfig;
+import tw.nekomimi.nekogram.helpers.AppRestartHelper;
 import tw.nekomimi.nekogram.helpers.PasscodeHelper;
 import tw.nekomimi.nekogram.ui.BottomBuilder;
 import tw.nekomimi.nekogram.ui.EditTextAutoFill;
@@ -10672,7 +10672,7 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
             restart.setTitle(LocaleController.getString(R.string.NekoX));
             restart.setMessage(LocaleController.getString(R.string.RestartAppToTakeEffect));
             restart.setPositiveButton(LocaleController.getString(R.string.OK), (__, ___) -> {
-                ProcessPhoenix.triggerRebirth(getContext(), new Intent(getContext(), LaunchActivity.class));
+                AppRestartHelper.triggerRebirth();
             });
             restart.show();
             return Unit.INSTANCE;

--- a/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
@@ -125,8 +125,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 
-import com.jakewharton.processphoenix.ProcessPhoenix;
-
 import org.telegram.PhoneFormat.PhoneFormat;
 import org.telegram.messenger.AccountInstance;
 import org.telegram.messenger.AndroidUtilities;

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/AppRestartHelper.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/AppRestartHelper.java
@@ -9,12 +9,20 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Process;
 
+import org.telegram.messenger.ApplicationLoader;
+import org.telegram.ui.LaunchActivity;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 
 public final class AppRestartHelper extends Activity {
     private static final String KEY_RESTART_INTENTS = "nagram_restart_intents";
     private static final String KEY_MAIN_PROCESS_PID = "nagram_main_process_pid";
+
+    public static void triggerRebirth() {
+        Context context = ApplicationLoader.applicationContext;
+        triggerRebirth(context, new Intent(context, LaunchActivity.class));
+    }
 
     public static void triggerRebirth(Context context, Intent... nextIntents) {
         nextIntents[0].addFlags(FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TASK);

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/AppRestartHelper.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/AppRestartHelper.java
@@ -1,0 +1,39 @@
+package tw.nekomimi.nekogram.helpers;
+
+import static android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK;
+import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Process;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public final class AppRestartHelper extends Activity {
+    private static final String KEY_RESTART_INTENTS = "nagram_restart_intents";
+    private static final String KEY_MAIN_PROCESS_PID = "nagram_main_process_pid";
+
+    public static void triggerRebirth(Context context, Intent... nextIntents) {
+        nextIntents[0].addFlags(FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TASK);
+        Intent intent = new Intent(context, AppRestartHelper.class);
+        intent.addFlags(FLAG_ACTIVITY_NEW_TASK);
+        intent.putParcelableArrayListExtra(KEY_RESTART_INTENTS, new ArrayList<>(Arrays.asList(nextIntents)));
+        intent.putExtra(KEY_MAIN_PROCESS_PID, Process.myPid());
+        context.startActivity(intent);
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Process.killProcess(getIntent().getIntExtra(KEY_MAIN_PROCESS_PID, -1));
+        ArrayList<Intent> intents = getIntent().getParcelableArrayListExtra(KEY_RESTART_INTENTS);
+        if (intents != null) {
+            startActivities(intents.toArray(new Intent[0]));
+            finish();
+            Runtime.getRuntime().exit(0);
+        }
+    }
+}

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/CloudSettingsHelper.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/CloudSettingsHelper.java
@@ -2,7 +2,6 @@ package tw.nekomimi.nekogram.helpers;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.os.Handler;
@@ -16,8 +15,6 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.core.graphics.ColorUtils;
-
-import com.jakewharton.processphoenix.ProcessPhoenix;
 
 import org.json.JSONException;
 import org.telegram.messenger.AndroidUtilities;
@@ -36,7 +33,6 @@ import org.telegram.ui.Components.CheckBoxSquare;
 import org.telegram.ui.Components.LayoutHelper;
 import org.telegram.ui.Components.ScaleStateListAnimator;
 import org.telegram.ui.Components.TextViewSwitcher;
-import org.telegram.ui.LaunchActivity;
 import org.telegram.ui.Stories.recorder.ButtonWithCounterView;
 
 import java.util.Calendar;
@@ -153,7 +149,7 @@ public class CloudSettingsHelper {
                     restart.setTitle(LocaleController.getString(R.string.NekoX));
                     restart.setMessage(LocaleController.getString(R.string.RestartAppToTakeEffect));
                     restart.setPositiveButton(LocaleController.getString(R.string.OK), (__, ___) -> {
-                        ProcessPhoenix.triggerRebirth(context, new Intent(context, LaunchActivity.class));
+                        AppRestartHelper.triggerRebirth();
                     });
                     restart.show();
                 }

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoSettingsActivity.java
@@ -5,7 +5,6 @@ import static tw.nekomimi.nekogram.utils.UpdateUtil.channelUsernameTips;
 
 import android.app.Activity;
 import android.content.Context;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.view.View;
 
@@ -15,7 +14,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import com.jakewharton.processphoenix.ProcessPhoenix;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -29,7 +27,6 @@ import org.telegram.ui.Cells.HeaderCell;
 import org.telegram.ui.Cells.TextCell;
 import org.telegram.ui.Cells.TextSettingsCell;
 import org.telegram.ui.DocumentSelectActivity;
-import org.telegram.ui.LaunchActivity;
 
 import java.io.File;
 import java.text.DateFormat;
@@ -126,7 +123,7 @@ public class NekoSettingsActivity extends BaseNekoSettingsActivity {
                         ApplicationLoader.applicationContext.getSharedPreferences("nekocloud", Activity.MODE_PRIVATE).edit().clear().commit();
                         ApplicationLoader.applicationContext.getSharedPreferences("nekox_config", Activity.MODE_PRIVATE).edit().clear().commit();
                         ApplicationLoader.applicationContext.getSharedPreferences("nkmrcfg", Activity.MODE_PRIVATE).edit().clear().commit();
-                        AppRestartHelper.triggerRebirth(getParentActivity(), new Intent(getParentActivity(), LaunchActivity.class));
+                        AppRestartHelper.triggerRebirth();
                     });
         } else if (position == exportSettingsRow) {
             backupSettings();
@@ -208,6 +205,8 @@ public class NekoSettingsActivity extends BaseNekoSettingsActivity {
                         textCell.setText(LocaleController.getString(R.string.ImportSettings), divider);
                     } else if (position == exportSettingsRow) {
                         textCell.setText(LocaleController.getString(R.string.BackupSettings), divider);
+                    } else if (position == resetSettingsRow) {
+                        textCell.setText(LocaleController.getString(R.string.ResetSettings), divider);
                     }
                     break;
                 }
@@ -413,7 +412,7 @@ public class NekoSettingsActivity extends BaseNekoSettingsActivity {
             AlertDialog restart = new AlertDialog(context, 0);
             restart.setTitle(LocaleController.getString(R.string.NekoX));
             restart.setMessage(LocaleController.getString(R.string.RestartAppToTakeEffect));
-            restart.setPositiveButton(LocaleController.getString(R.string.OK), (__, ___) -> ProcessPhoenix.triggerRebirth(context, new Intent(context, LaunchActivity.class)));
+            restart.setPositiveButton(LocaleController.getString(R.string.OK), (__, ___) -> AppRestartHelper.triggerRebirth());
             restart.show();
         } catch (Exception e) {
             AlertUtil.showSimpleAlert(context, e);

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoSettingsActivity.java
@@ -40,6 +40,7 @@ import java.util.function.Function;
 
 import kotlin.text.StringsKt;
 import tw.nekomimi.nekogram.DatacenterActivity;
+import tw.nekomimi.nekogram.helpers.AppRestartHelper;
 import tw.nekomimi.nekogram.helpers.CloudSettingsHelper;
 import tw.nekomimi.nekogram.helpers.PasscodeHelper;
 import tw.nekomimi.nekogram.utils.AlertUtil;
@@ -72,6 +73,7 @@ public class NekoSettingsActivity extends BaseNekoSettingsActivity {
     private int settingsRow;
     private int importSettingsRow;
     private int exportSettingsRow;
+    private int resetSettingsRow;
     private int settings2Row;
 
     @Override
@@ -114,6 +116,18 @@ public class NekoSettingsActivity extends BaseNekoSettingsActivity {
         }  else if (position == importSettingsRow) {
             DocumentSelectActivity activity = getDocumentSelectActivity(getParentActivity());
             presentFragment(activity);
+        } else if (position == resetSettingsRow) {
+            AlertUtil.showConfirm(getParentActivity(),
+                    LocaleController.getString(R.string.ResetSettingsAlert),
+                    R.drawable.msg_reset,
+                    LocaleController.getString(R.string.Reset),
+                    true,
+                    () -> {
+                        ApplicationLoader.applicationContext.getSharedPreferences("nekocloud", Activity.MODE_PRIVATE).edit().clear().commit();
+                        ApplicationLoader.applicationContext.getSharedPreferences("nekox_config", Activity.MODE_PRIVATE).edit().clear().commit();
+                        ApplicationLoader.applicationContext.getSharedPreferences("nkmrcfg", Activity.MODE_PRIVATE).edit().clear().commit();
+                        AppRestartHelper.triggerRebirth(getParentActivity(), new Intent(getParentActivity(), LaunchActivity.class));
+                    });
         } else if (position == exportSettingsRow) {
             backupSettings();
         }
@@ -163,6 +177,7 @@ public class NekoSettingsActivity extends BaseNekoSettingsActivity {
         settingsRow = addRow("settings");
         importSettingsRow = addRow("importSettings");
         exportSettingsRow = addRow("exportSettings");
+        resetSettingsRow = addRow("resetSettings");
         settings2Row = addRow();
     }
 

--- a/TMessagesProj/src/main/res/values-es-rES/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-es-rES/strings_na.xml
@@ -59,6 +59,8 @@
     <string name="QuickToggleAnonymous">Cambio rápido a anónimo</string>
     <string name="QuickToggleAnonymousNotice">Si eres el dueño del grupo</string>
     <string name="RealHideTimeForSticker">Tiempo de ocultación real para stickers</string>
+    <string name="ResetSettings">Restablecer Ajustes</string>
+    <string name="ResetSettingsAlert">¿Está seguro de que desea restablecer todos los N-Ajustes?</string>
     <string name="HideTitle">Ocultar el título</string>
     <string name="IgnoreFolderCount">Ignorar contador de carpetas</string>
     <string name="SendWithoutMarkdown">Enviar sin markdown</string>

--- a/TMessagesProj/src/main/res/values-in-rID/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-in-rID/strings_na.xml
@@ -59,6 +59,8 @@
     <string name="QuickToggleAnonymous">Quick toggle anonymous</string>
     <string name="QuickToggleAnonymousNotice">If you\'re owner of the group</string>
     <string name="RealHideTimeForSticker">Real hide time for stickers</string>
+    <string name="ResetSettings">Atur Ulang Pengaturan</string>
+    <string name="ResetSettingsAlert">Apakah Anda yakin ingin mengatur ulang semua Pengaturan-N?</string>
     <string name="HideTitle">Hide Title</string>
     <string name="IgnoreFolderCount">Ignore Folder Count</string>
     <string name="SendWithoutMarkdown">Send without markdown</string>

--- a/TMessagesProj/src/main/res/values-it-rIT/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-it-rIT/strings_na.xml
@@ -59,6 +59,8 @@
     <string name="QuickToggleAnonymous">Attiva/disattiva velocemente anonimo</string>
     <string name="QuickToggleAnonymousNotice">Se sei proprietario del gruppo</string>
     <string name="RealHideTimeForSticker">Tempo di nascondersi reale per gli adesivi</string>
+    <string name="ResetSettings">Ripristina le Impostazioni</string>
+    <string name="ResetSettingsAlert">Sei sicuro di voler ripristinare tutte le impostazioni?</string>
     <string name="HideTitle">Nascondi Titolo</string>
     <string name="IgnoreFolderCount">Ignora Conteggio Cartelle</string>
     <string name="SendWithoutMarkdown">Invia senza markdown</string>

--- a/TMessagesProj/src/main/res/values-ja-rJP/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-ja-rJP/strings_na.xml
@@ -59,6 +59,8 @@
     <string name="QuickToggleAnonymous">クイック匿名の切り替え</string>
     <string name="QuickToggleAnonymousNotice">あなたがグループの所有者である場合</string>
     <string name="RealHideTimeForSticker">ステッカーをリアルタイムに隠す</string>
+    <string name="ResetSettings">設定をリセット</string>
+    <string name="ResetSettingsAlert">「N-設定」をリセットしますか？</string>
     <string name="HideTitle">タイトルを隠す</string>
     <string name="IgnoreFolderCount">フォルダ数を無視</string>
     <string name="SendWithoutMarkdown">マークダウンなしで送信</string>

--- a/TMessagesProj/src/main/res/values-pl-rPL/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-pl-rPL/strings_na.xml
@@ -59,6 +59,8 @@
     <string name="QuickToggleAnonymous">Szybkie przełączanie anonimowe</string>
     <string name="QuickToggleAnonymousNotice">Jeśli jesteś właścicielem grupy</string>
     <string name="RealHideTimeForSticker">Prawdziwy czas ukrycia naklejek</string>
+    <string name="ResetSettings">Resetuj ustawienia</string>
+    <string name="ResetSettingsAlert">Czy na pewno chcesz zresetować wszystkie ustawienia-N?</string>
     <string name="HideTitle">Ukryj tytuł</string>
     <string name="IgnoreFolderCount">Ignoruj liczbę folderów</string>
     <string name="SendWithoutMarkdown">Wyślij bez markdown</string>

--- a/TMessagesProj/src/main/res/values-pt-rBR/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-pt-rBR/strings_na.xml
@@ -59,6 +59,8 @@
     <string name="QuickToggleAnonymous">Alternador rápido anônimo</string>
     <string name="QuickToggleAnonymousNotice">Se você é o proprietário do grupo</string>
     <string name="RealHideTimeForSticker">Ocultar tempo real para adesivos</string>
+    <string name="ResetSettings">Redefinir configurações</string>
+    <string name="ResetSettingsAlert">Tem certeza de que deseja redefinir todas as N-Configurações?</string>
     <string name="HideTitle">Ocultar o título</string>
     <string name="IgnoreFolderCount">Ignorar contador de pastas</string>
     <string name="SendWithoutMarkdown">Enviar sem markdown</string>

--- a/TMessagesProj/src/main/res/values-ru-rRU/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-ru-rRU/strings_na.xml
@@ -59,6 +59,8 @@
     <string name="QuickToggleAnonymous">Быстрое переключение анонимности</string>
     <string name="QuickToggleAnonymousNotice">Если вы владелец группы.</string>
     <string name="RealHideTimeForSticker">Скрыть время для стикеров</string>
+    <string name="ResetSettings">Сброс настроек</string>
+    <string name="ResetSettingsAlert">Вы уверены, что хотите сбросить все «Настройки N»?</string>
     <string name="HideTitle">Скрыть заголовок</string>
     <string name="IgnoreFolderCount">Игнорировать количество папок</string>
     <string name="SendWithoutMarkdown">Отправить без разметки</string>

--- a/TMessagesProj/src/main/res/values-tr-rTR/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-tr-rTR/strings_na.xml
@@ -59,6 +59,8 @@
     <string name="QuickToggleAnonymous">Anonimlere hızlı geçiş</string>
     <string name="QuickToggleAnonymousNotice">Grubun sahibiyseniz</string>
     <string name="RealHideTimeForSticker">Çıkartmalar için gerçek saklanma süresi</string>
+    <string name="ResetSettings">Ayarları Sıfırla</string>
+    <string name="ResetSettingsAlert">Tüm N-Ayarlarını sıfırlamak istediğinizden emin misiniz?</string>
     <string name="HideTitle">Başlığı Gizle</string>
     <string name="IgnoreFolderCount">Klasör Sayısını Yoksay</string>
     <string name="SendWithoutMarkdown">İşaretlemeden gönder</string>

--- a/TMessagesProj/src/main/res/values-uk-rUA/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-uk-rUA/strings_na.xml
@@ -59,6 +59,8 @@
     <string name="QuickToggleAnonymous">Швидкий перемикач анонімного режиму</string>
     <string name="QuickToggleAnonymousNotice">Якщо ви власник групи</string>
     <string name="RealHideTimeForSticker">Реальний час приховування для наліпок</string>
+    <string name="ResetSettings">Скидання налаштувань</string>
+    <string name="ResetSettingsAlert">Ви дійсно бажаєте скинути всі N-Налаштування?</string>
     <string name="HideTitle">Приховати заголовок</string>
     <string name="IgnoreFolderCount">Ігнорувати кількість папок</string>
     <string name="SendWithoutMarkdown">Відправити без markdown</string>

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
@@ -59,6 +59,8 @@
     <string name="QuickToggleAnonymous">快速切换匿名发言</string>
     <string name="QuickToggleAnonymousNotice">如果你是群组的所有者的话</string>
     <string name="RealHideTimeForSticker">真正的隐藏贴纸发送时间</string>
+    <string name="ResetSettings">重置设置</string>
+    <string name="ResetSettingsAlert">您确定要重置所有 N-设置 吗？</string>
     <string name="HideTitle">隐藏标题和头像</string>
     <string name="IgnoreFolderCount">忽略文件夹标签上的未读计数</string>
     <string name="SendWithoutMarkdown">禁用 Markdown</string>

--- a/TMessagesProj/src/main/res/values-zh-rTW/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rTW/strings_na.xml
@@ -59,6 +59,8 @@
     <string name="QuickToggleAnonymous">快速切換匿名發言</string>
     <string name="QuickToggleAnonymousNotice">如果你是頻道的持有者則可以使用頻道匿名發言</string>
     <string name="RealHideTimeForSticker">真正的隱藏貼圖傳送時間</string>
+    <string name="ResetSettings">重置設定</string>
+    <string name="ResetSettingsAlert">您確定要重置所有 N-設定 嗎？</string>
     <string name="HideTitle">隱藏標題和頭像</string>
     <string name="IgnoreFolderCount">忽略資料夾標籤上的未讀計數</string>
     <string name="SendWithoutMarkdown">禁用 Markdown</string>

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -59,6 +59,8 @@
     <string name="QuickToggleAnonymous">Quick toggle anonymous</string>
     <string name="QuickToggleAnonymousNotice">If you\'re owner of the group</string>
     <string name="RealHideTimeForSticker">Real hide time for stickers</string>
+    <string name="ResetSettings">Reset Settings</string>
+    <string name="ResetSettingsAlert">Are you sure you want to reset all N-Settings?</string>
     <string name="HideTitle">Hide Title</string>
     <string name="IgnoreFolderCount">Ignore Folder Count</string>
     <string name="SendWithoutMarkdown">Send without markdown</string>


### PR DESCRIPTION
thanks to @NagramX

files and codes borrowed from:
https://github.com/risin42/NagramX/blob/beaec62055fdab95aab31c55d7a809c6f2289bb8/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/AppRestartHelper.java
https://github.com/risin42/NagramX/blob/beaec62055fdab95aab31c55d7a809c6f2289bb8/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoSettingsActivity.java#L81
https://github.com/risin42/NagramX/blob/beaec62055fdab95aab31c55d7a809c6f2289bb8/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoSettingsActivity.java#L105
https://github.com/risin42/NagramX/blob/beaec62055fdab95aab31c55d7a809c6f2289bb8/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoSettingsActivity.java#L355-L366
https://github.com/risin42/NagramX/blob/6dc11748b1bb8347532b5926ac0349106e2e37f9/TMessagesProj/src/main/res/values

## Summary by Sourcery

Add a settings option to reset all Neko-related preferences and restart the app to apply a clean configuration state.

New Features:
- Introduce a reset settings row in Neko settings that clears all Neko-related shared preferences and relaunches the app.
- Add a helper activity to handle app process restart and relaunch intents after resetting settings.