### PR TITLE
fix: hide stories floating button

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
@@ -9037,7 +9037,7 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
             floatingButton3.setButtonVisible(isVisible, animated);
         }
         if (floatingButtonStories != null) {
-            floatingButtonStories.setButtonVisible(isVisible, animated);
+            floatingButtonStories.setButtonVisible(isVisible && !NaConfig.INSTANCE.getDisableStories().Bool(), animated);
         }
     }
 


### PR DESCRIPTION
if Disable Stories is enabled it won't hide the floating button, this PR would solve the issue.

## Summary by Sourcery

Bug Fixes:
- Ensure the stories floating button in home screen is hidden when the "Disable Stories" option is enabled.