### PR TITLE
fix: hide stories floating ring

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/StoriesController.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/StoriesController.java
@@ -1394,6 +1394,7 @@ public class StoriesController {
     }
 
     public boolean hasLiveStory(long dialogId) {
+        if (NaConfig.INSTANCE.getDisableStories().Bool()) return false;
         TL_stories.PeerStories userStories = allStoriesMap.get(dialogId);
         if (userStories == null) {
             userStories = getStoriesFromFullPeer(dialogId);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/StoriesUtilities.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/StoriesUtilities.java
@@ -165,6 +165,10 @@ public class StoriesUtilities {
             unreadState = state = params.forceState;
         }
 
+        if (NaConfig.INSTANCE.getDisableStories().Bool()) {
+            unreadState = state = STATE_EMPTY;
+        }
+
         if (params.currentState != state) {
             if (params.currentState == STATE_PROGRESS) {
                 animated = true;
@@ -192,7 +196,7 @@ public class StoriesUtilities {
             params.inc = false;
         }
         params.showProgress = showProgress;
-        if (NaConfig.INSTANCE.getDisableStories().Bool() || params.currentState == STATE_EMPTY && params.progressToSate == 1f) {
+        if (params.currentState == STATE_EMPTY && params.progressToSate == 1f) {
             avatarImage.setImageCoords(params.originalAvatarRect);
             canvas.save();
             canvas.scale(scale, scale, params.originalAvatarRect.centerX(), params.originalAvatarRect.centerY());

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/StoriesUtilities.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/StoriesUtilities.java
@@ -192,7 +192,7 @@ public class StoriesUtilities {
             params.inc = false;
         }
         params.showProgress = showProgress;
-        if (params.currentState == STATE_EMPTY && params.progressToSate == 1f) {
+        if (NaConfig.INSTANCE.getDisableStories().Bool() || params.currentState == STATE_EMPTY && params.progressToSate == 1f) {
             avatarImage.setImageCoords(params.originalAvatarRect);
             canvas.save();
             canvas.scale(scale, scale, params.originalAvatarRect.centerX(), params.originalAvatarRect.centerY());


### PR DESCRIPTION
if Disable Stories is enabled it won't hide the floating ring in profile pictures, this PR would solve the issue.

## Summary by Sourcery

Bug Fixes:
- Hide the stories floating ring on profile pictures when the Disable Stories option is enabled.