### PR TITLE
Fix admin log pagination after collapsed deletions

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChannelAdminLogActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChannelAdminLogActivity.java
@@ -640,7 +640,8 @@ public class ChannelAdminLogActivity extends BaseFragment implements Notificatio
 
                     if (chatAdapter != null) {
                         chatAdapter.notifyDataSetChanged();
-                        chatListView.post(() -> checkScrollForLoad(true));
+                        // na: fix admin log pagination after collapsed deletions- #73
+                        if (chatListView != null) chatListView.post(() -> checkScrollForLoad(true));
                     }
 
                     if (searchItem != null) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChannelAdminLogActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChannelAdminLogActivity.java
@@ -640,6 +640,7 @@ public class ChannelAdminLogActivity extends BaseFragment implements Notificatio
 
                     if (chatAdapter != null) {
                         chatAdapter.notifyDataSetChanged();
+                        chatListView.post(() -> checkScrollForLoad(true));
                     }
 
                     if (searchItem != null) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix admin log pagination not loading more messages when items are removed and the list becomes short after deletions.