### PR TITLE
fix(chat): avoid NPE when channel admin cache is unavailable

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
@@ -7699,6 +7699,7 @@ public class MessagesController extends BaseController implements NotificationCe
                     }
                 }
             }
+            return null;
         }
         return array.get(uid);
     }
@@ -7716,6 +7717,7 @@ public class MessagesController extends BaseController implements NotificationCe
                     }
                 }
             }
+            return false;
         }
         final TLRPC.ChannelParticipant participant = array.get(uid);
         return participant instanceof TLRPC.TL_channelParticipantAdmin || participant instanceof TLRPC.TL_channelParticipantCreator;
@@ -7736,6 +7738,7 @@ public class MessagesController extends BaseController implements NotificationCe
                     }
                 }
             }
+            return false;
         }
         final TLRPC.ChannelParticipant participant = array.get(uid);
         return participant instanceof TLRPC.TL_channelParticipantCreator;

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
@@ -7706,20 +7706,42 @@ public class MessagesController extends BaseController implements NotificationCe
 
     public boolean isAdmin(long chatId, long uid) {
         if (chatId == uid) return true;
-        final TLObject participant = getParticipant(chatId, uid);
-        return participant instanceof TLRPC.TL_channelParticipantAdmin
-                || participant instanceof TLRPC.TL_channelParticipantCreator
-                || participant instanceof TLRPC.TL_chatParticipantAdmin
-                || participant instanceof TLRPC.TL_chatParticipantCreator;
+        final LongSparseArray<TLRPC.ChannelParticipant> array = channelAdmins.get(chatId);
+        if (array == null) {
+            final TLRPC.ChatFull chatFull = getChatFull(chatId);
+            if (chatFull != null && chatFull.participants != null) {
+                for (int i = 0; i < chatFull.participants.participants.size(); ++i) {
+                    final TLRPC.ChatParticipant p = chatFull.participants.participants.get(i);
+                    if (p.user_id == uid) {
+                        return p instanceof TLRPC.TL_chatParticipantAdmin || p instanceof TLRPC.TL_chatParticipantCreator;
+                    }
+                }
+            }
+            return false;
+        }
+        final TLRPC.ChannelParticipant participant = array.get(uid);
+        return participant instanceof TLRPC.TL_channelParticipantAdmin || participant instanceof TLRPC.TL_channelParticipantCreator;
     }
 
     public boolean isOwner(long chatId, long uid) {
         if (chatId == uid) return true;
         final TLRPC.Chat chat = getChat(chatId);
         if (getUserConfig().getClientUserId() == uid && chat != null && chat.creator) return true;
-        final TLObject participant = getParticipant(chatId, uid);
-        return participant instanceof TLRPC.TL_channelParticipantCreator
-                || participant instanceof TLRPC.TL_chatParticipantCreator;
+        final LongSparseArray<TLRPC.ChannelParticipant> array = channelAdmins.get(chatId);
+        if (array == null) {
+            final TLRPC.ChatFull chatFull = getChatFull(chatId);
+            if (chatFull != null && chatFull.participants != null) {
+                for (int i = 0; i < chatFull.participants.participants.size(); ++i) {
+                    final TLRPC.ChatParticipant p = chatFull.participants.participants.get(i);
+                    if (p.user_id == uid) {
+                        return p instanceof TLRPC.TL_chatParticipantCreator;
+                    }
+                }
+            }
+            return false;
+        }
+        final TLRPC.ChannelParticipant participant = array.get(uid);
+        return participant instanceof TLRPC.TL_channelParticipantCreator;
     }
 
     public boolean isChannelAdminsLoaded(long chatId) {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
@@ -7706,42 +7706,20 @@ public class MessagesController extends BaseController implements NotificationCe
 
     public boolean isAdmin(long chatId, long uid) {
         if (chatId == uid) return true;
-        final LongSparseArray<TLRPC.ChannelParticipant> array = channelAdmins.get(chatId);
-        if (array == null) {
-            final TLRPC.ChatFull chatFull = getChatFull(chatId);
-            if (chatFull != null && chatFull.participants != null) {
-                for (int i = 0; i < chatFull.participants.participants.size(); ++i) {
-                    final TLRPC.ChatParticipant p = chatFull.participants.participants.get(i);
-                    if (p.user_id == uid) {
-                        return p instanceof TLRPC.TL_chatParticipantAdmin || p instanceof TLRPC.TL_chatParticipantCreator;
-                    }
-                }
-            }
-            return false;
-        }
-        final TLRPC.ChannelParticipant participant = array.get(uid);
-        return participant instanceof TLRPC.TL_channelParticipantAdmin || participant instanceof TLRPC.TL_channelParticipantCreator;
+        final TLObject participant = getParticipant(chatId, uid);
+        return participant instanceof TLRPC.TL_channelParticipantAdmin
+                || participant instanceof TLRPC.TL_channelParticipantCreator
+                || participant instanceof TLRPC.TL_chatParticipantAdmin
+                || participant instanceof TLRPC.TL_chatParticipantCreator;
     }
 
     public boolean isOwner(long chatId, long uid) {
         if (chatId == uid) return true;
         final TLRPC.Chat chat = getChat(chatId);
         if (getUserConfig().getClientUserId() == uid && chat != null && chat.creator) return true;
-        final LongSparseArray<TLRPC.ChannelParticipant> array = channelAdmins.get(chatId);
-        if (array == null) {
-            final TLRPC.ChatFull chatFull = getChatFull(chatId);
-            if (chatFull != null && chatFull.participants != null) {
-                for (int i = 0; i < chatFull.participants.participants.size(); ++i) {
-                    final TLRPC.ChatParticipant p = chatFull.participants.participants.get(i);
-                    if (p.user_id == uid) {
-                        return p instanceof TLRPC.TL_chatParticipantCreator;
-                    }
-                }
-            }
-            return false;
-        }
-        final TLRPC.ChannelParticipant participant = array.get(uid);
-        return participant instanceof TLRPC.TL_channelParticipantCreator;
+        final TLObject participant = getParticipant(chatId, uid);
+        return participant instanceof TLRPC.TL_channelParticipantCreator
+                || participant instanceof TLRPC.TL_chatParticipantCreator;
     }
 
     public boolean isChannelAdminsLoaded(long chatId) {


### PR DESCRIPTION
When the channel admin cache is unavailable, the fallback lookup may access a null `LongSparseArray` if no matching participant is found, causing the app to crash.

## Crash log

```text
1785848614.886 10336 13431 13431 E AndroidRuntime: FATAL EXCEPTION: main
1785848614.886 10336 13431 13431 E AndroidRuntime: Process: xyz.nextalone.nagram, PID: 13431
1785848614.886 10336 13431 13431 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object androidx.collection.LongSparseArray.get(long)' on a null object reference
1785848614.886 10336 13431 13431 E AndroidRuntime:     at org.telegram.ui.ChatActivity$ChatMessageCellDelegate.isOwner(ChatActivity.java:114)
1785848614.886 10336 13431 13431 E AndroidRuntime:     at org.telegram.ui.Cells.ChatMessageCell.setMessageObjectInternal(ChatMessageCell.java:863)
1785848614.886 10336 13431 13431 E AndroidRuntime:     at org.telegram.ui.Cells.ChatMessageCell.setMessageContent(ChatMessageCell.java:1701)
1785848614.886 10336 13431 13431 E AndroidRuntime:     at org.telegram.ui.Cells.ChatMessageCell.onAttachedToWindow(ChatMessageCell.java:142)
```

## Summary by Sourcery

Prevent null pointer crashes when resolving channel participants and admin status from the channel admin cache.

Bug Fixes:
- Return null when a channel participant lookup falls back to a missing admin cache array instead of dereferencing a null value.
- Return false for admin and owner checks when the channel admin cache array is unavailable, avoiding NPEs during message rendering.