### PR TITLE
style: tg://user open profile

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -1579,11 +1579,7 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
         return overlayPasscodeViews.isEmpty() && this.passcodeDialog != null ? passcodeView == this.passcodeDialog.passcodeView : overlayPasscodeViews.get(overlayPasscodeViews.size() - 1) == passcodeView;
     }
 
-    private boolean handleIntent(Intent intent, boolean isNew, boolean restore, boolean fromPassword) {
-        return handleIntent(intent, isNew, restore, fromPassword, null, true, false);
-    }
-
-    private TLRPC.User resolveLinkUserOrShowError(int account, long userId) {
+    public static TLRPC.User resolveLinkUserOrShowError(int account, long userId) {
         TLRPC.User user = MessagesController.getInstance(account).getUser(userId);
         if (user == null) {
             user = MessagesStorage.getInstance(account).getUserSync(userId);
@@ -1595,6 +1591,10 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
             BulletinFactory.global().createErrorBulletin(LocaleController.getString(R.string.NoUsernameFound2)).show();
         }
         return user;
+    }
+
+    private boolean handleIntent(Intent intent, boolean isNew, boolean restore, boolean fromPassword) {
+        return handleIntent(intent, isNew, restore, fromPassword, null, true, false);
     }
 
     @SuppressLint("Range")
@@ -2273,7 +2273,7 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
                                                 try {
                                                     long userId = Utilities.parseLong(StringsKt.substringAfter(path, "@id", "0"));
                                                     if (userId != 0) {
-                                                        push_user_id = userId;
+                                                        open_user_id = userId;
                                                     }
                                                 } catch (Exception e) {
                                                     FileLog.e(e);
@@ -2751,12 +2751,16 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
                                             open_settings = 1;
                                         }
                                     } else if (url.startsWith("tg:user") || url.startsWith("tg://user")) {
-                                        url = url.replace("tg:user", "tg://telegram.org").replace("tg://user", "tg://telegram.org");
-                                        data = Uri.parse(url);
-
                                         try {
-                                            open_user_id = Long.parseLong(data.getQueryParameter("id"));
-                                        } catch (NumberFormatException ignore) {}
+                                            url = url.replace("tg:user", "tg://telegram.org").replace("tg://user", "tg://telegram.org");
+                                            data = Uri.parse(url);
+                                            long userId = Utilities.parseLong(data.getQueryParameter("id"));
+                                            if (userId != 0) {
+                                                open_user_id = userId;
+                                            }
+                                        } catch (Exception e) {
+                                            FileLog.e(e);
+                                        }
                                     } else if (url.startsWith("tg:upgrade") || url.startsWith("tg://upgrade") || url.startsWith("tg:update") || url.startsWith("tg://update")) {
                                         boolean updateAlways = false;
                                         try {
@@ -3144,7 +3148,7 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
                     } else {
                         VoIPPendingCall.startOrSchedule(this, push_user_id, videoCallUser, AccountInstance.getInstance(intentAccount[0]));
                     }
-                } else if (resolveLinkUserOrShowError(intentAccount[0], push_user_id) != null) {
+                } else {
                     Bundle args = new Bundle();
                     args.putLong("user_id", push_user_id);
                     if (push_msg_id != 0) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -1583,6 +1583,20 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
         return handleIntent(intent, isNew, restore, fromPassword, null, true, false);
     }
 
+    private TLRPC.User resolveLinkUserOrShowError(int account, long userId) {
+        TLRPC.User user = MessagesController.getInstance(account).getUser(userId);
+        if (user == null) {
+            user = MessagesStorage.getInstance(account).getUserSync(userId);
+            if (user != null) {
+                MessagesController.getInstance(account).putUser(user, true);
+            }
+        }
+        if (user == null) {
+            BulletinFactory.global().createErrorBulletin(LocaleController.getString(R.string.NoUsernameFound2)).show();
+        }
+        return user;
+    }
+
     @SuppressLint("Range")
     private boolean handleIntent(Intent intent, boolean isNew, boolean restore, boolean fromPassword, Browser.Progress progress, boolean rebuildFragments, boolean openedTelegram) {
         if (GiftInfoBottomSheet.handleIntent(intent, progress)) {
@@ -1637,6 +1651,7 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
         int open_widget_edit = -1;
         int open_widget_edit_type = -1;
         int open_new_dialog = 0;
+        long open_user_id = 0;
         long dialogId = 0;
         boolean showDialogsList = false;
         boolean showPlayer = false;
@@ -2736,16 +2751,12 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
                                             open_settings = 1;
                                         }
                                     } else if (url.startsWith("tg:user") || url.startsWith("tg://user")) {
+                                        url = url.replace("tg:user", "tg://telegram.org").replace("tg://user", "tg://telegram.org");
+                                        data = Uri.parse(url);
+
                                         try {
-                                            url = url.replace("tg:user", "tg://telegram.org").replace("tg://user", "tg://telegram.org");
-                                            data = Uri.parse(url);
-                                            long userId = Utilities.parseLong(data.getQueryParameter("id"));
-                                            if (userId != 0) {
-                                                push_user_id = userId;
-                                            }
-                                        } catch (Exception e) {
-                                            FileLog.e(e);
-                                        }
+                                            open_user_id = Long.parseLong(data.getQueryParameter("id"));
+                                        } catch (NumberFormatException ignore) {}
                                     } else if (url.startsWith("tg:upgrade") || url.startsWith("tg://upgrade") || url.startsWith("tg:update") || url.startsWith("tg://update")) {
                                         boolean updateAlways = false;
                                         try {
@@ -3133,7 +3144,7 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
                     } else {
                         VoIPPendingCall.startOrSchedule(this, push_user_id, videoCallUser, AccountInstance.getInstance(intentAccount[0]));
                     }
-                } else {
+                } else if (resolveLinkUserOrShowError(intentAccount[0], push_user_id) != null) {
                     Bundle args = new Bundle();
                     args.putLong("user_id", push_user_id);
                     if (push_msg_id != 0) {
@@ -3142,6 +3153,23 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
                     if (mainFragmentsStack.isEmpty() || MessagesController.getInstance(intentAccount[0]).checkCanOpenChat(args, mainFragmentsStack.get(mainFragmentsStack.size() - 1))) {
                         ChatActivity fragment = new ChatActivity(args);
                         if (getActionBarLayout().presentFragment(new INavigationLayout.NavigationParams(fragment).setNoAnimation(true))) {
+                            pushOpened = true;
+                            LaunchActivity.dismissAllWeb();
+                        }
+                    }
+                }
+            } else if (open_user_id != 0) {
+                TLRPC.User user = resolveLinkUserOrShowError(intentAccount[0], open_user_id);
+                if (user != null) {
+                    BaseFragment lastFragment = actionBarLayout.getLastFragment();
+                    if (lastFragment != null) {
+                        MessagesController.getInstance(intentAccount[0]).openChatOrProfileWith(user, null, lastFragment, 0, false);
+                        pushOpened = true;
+                        LaunchActivity.dismissAllWeb();
+                    } else {
+                        Bundle args = new Bundle();
+                        args.putLong("user_id", open_user_id);
+                        if (getActionBarLayout().presentFragment(new INavigationLayout.NavigationParams(new ProfileActivity(args)).setNoAnimation(true))) {
                             pushOpened = true;
                             LaunchActivity.dismissAllWeb();
                         }


### PR DESCRIPTION
thanks to @forkgram

hi there, the tg://user should open the profile instead of opening messages with the user.

https://github.com/forkgram/TelegramAndroid/commit/4cc95295b811881ff37c5b7d7d9bf8b4ce2b356f

## Summary by Sourcery

Handle tg://user intents by resolving the target user and opening their profile screen, with graceful error handling if the user cannot be found.

New Features:
- Open tg://user links directly to the user profile instead of starting a message dialog.

Bug Fixes:
- Prevent crashes or invalid navigation when tg://user links reference users not yet loaded by resolving them from storage or showing an error state.

Enhancements:
- Introduce a helper to resolve users from controller or storage and surface a user-not-found bulletin for link-based navigation.