### PR TITLE
feat: disable glare effects

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/drawable/BlurredBackgroundDrawable.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/drawable/BlurredBackgroundDrawable.java
@@ -42,6 +42,8 @@ import org.telegram.ui.Components.blur3.utils.NinePatchBuilder;
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
 
+import xyz.nextalone.nagram.NaConfig;
+
 public abstract class BlurredBackgroundDrawable extends Drawable {
     public BlurredBackgroundDrawable() {
         boundProps.strokeWidthTop = dpf2(1);
@@ -395,6 +397,7 @@ public abstract class BlurredBackgroundDrawable extends Drawable {
         float[] radii, float strokeWidth, boolean isTop,
         Paint paint
     ) {
+        if (!NaConfig.INSTANCE.getStrokeOnViews().Bool()) return;
 
         final boolean radiiAreSame = isTop ?
             radii[0] == radii[1] && radii[1] == radii[2] && radii[2] == radii[3]:
@@ -491,6 +494,7 @@ public abstract class BlurredBackgroundDrawable extends Drawable {
 
     public static void drawStroke(Canvas canvas, RectF rect,
                                      float radii, float strokeWidth, boolean isTop, Paint paint) {
+        if (!NaConfig.INSTANCE.getStrokeOnViews().Bool()) return;
         drawStroke(canvas, rect.left, rect.top, rect.right, rect.bottom, radii, strokeWidth, isTop, paint);
     }
 
@@ -649,7 +653,7 @@ public abstract class BlurredBackgroundDrawable extends Drawable {
             return;
         }
 
-        final NinePatchDrawable ninePatchDrawable = checkNinePatchDrawable(fillColor, true);
+        final NinePatchDrawable ninePatchDrawable = checkNinePatchDrawable(fillColor, NaConfig.INSTANCE.getStrokeOnViews().Bool());
         ninePatchDrawable.setBounds(
             boundProps.boundsWithPadding.left - ninePatchDrawablePadding.left,
             boundProps.boundsWithPadding.top - ninePatchDrawablePadding.top,
@@ -704,6 +708,7 @@ public abstract class BlurredBackgroundDrawable extends Drawable {
     }
 
     private void drawStrokeInternalIfNeeded(Canvas canvas) {
+        if (!NaConfig.INSTANCE.getStrokeOnViews().Bool()) return;
         final int strokeColorTop = Theme.multAlpha(this.strokeColorTop, alpha / 255f);
         final int strokeColorBottom = Theme.multAlpha(this.strokeColorBottom, alpha / 255f);
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/drawable/BlurredBackgroundDrawable.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/drawable/BlurredBackgroundDrawable.java
@@ -397,7 +397,7 @@ public abstract class BlurredBackgroundDrawable extends Drawable {
         float[] radii, float strokeWidth, boolean isTop,
         Paint paint
     ) {
-        if (!NaConfig.INSTANCE.getStrokeOnViews().Bool()) return;
+        if (NaConfig.INSTANCE.getDisableGlareEffects().Bool()) return;
 
         final boolean radiiAreSame = isTop ?
             radii[0] == radii[1] && radii[1] == radii[2] && radii[2] == radii[3]:
@@ -494,12 +494,12 @@ public abstract class BlurredBackgroundDrawable extends Drawable {
 
     public static void drawStroke(Canvas canvas, RectF rect,
                                      float radii, float strokeWidth, boolean isTop, Paint paint) {
-        if (!NaConfig.INSTANCE.getStrokeOnViews().Bool()) return;
         drawStroke(canvas, rect.left, rect.top, rect.right, rect.bottom, radii, strokeWidth, isTop, paint);
     }
 
     public static void drawStroke(Canvas canvas, float left, float top, float right, float bottom,
                                      float radii, float strokeWidth, boolean isTop, Paint paint) {
+        if (NaConfig.INSTANCE.getDisableGlareEffects().Bool()) return;
         final float strokeHalf = strokeWidth / 2f;
         canvas.save();
         if (isTop) {
@@ -653,7 +653,7 @@ public abstract class BlurredBackgroundDrawable extends Drawable {
             return;
         }
 
-        final NinePatchDrawable ninePatchDrawable = checkNinePatchDrawable(fillColor, NaConfig.INSTANCE.getStrokeOnViews().Bool());
+        final NinePatchDrawable ninePatchDrawable = checkNinePatchDrawable(fillColor, !NaConfig.INSTANCE.getDisableGlareEffects().Bool());
         ninePatchDrawable.setBounds(
             boundProps.boundsWithPadding.left - ninePatchDrawablePadding.left,
             boundProps.boundsWithPadding.top - ninePatchDrawablePadding.top,
@@ -708,7 +708,7 @@ public abstract class BlurredBackgroundDrawable extends Drawable {
     }
 
     private void drawStrokeInternalIfNeeded(Canvas canvas) {
-        if (!NaConfig.INSTANCE.getStrokeOnViews().Bool()) return;
+        if (NaConfig.INSTANCE.getDisableGlareEffects().Bool()) return;
         final int strokeColorTop = Theme.multAlpha(this.strokeColorTop, alpha / 255f);
         final int strokeColorBottom = Theme.multAlpha(this.strokeColorBottom, alpha / 255f);
 

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
@@ -206,6 +206,7 @@ private final AbstractConfigCell defaultHlsVideoQualityRow = cellGroup.appendCel
     private final AbstractConfigCell typefaceRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.typeface));
     private final AbstractConfigCell transparentStatusBarRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.transparentStatusBar));
     private final AbstractConfigCell appBarShadowRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.disableAppBarShadow));
+    private final AbstractConfigCell strokeOnViewsRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getStrokeOnViews()));
     private final AbstractConfigCell newYearRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.newYear));
     private final AbstractConfigCell alwaysShowDownloadIconRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getAlwaysShowDownloadIcon()));
     private final AbstractConfigCell actionBarDecorationRow = cellGroup.appendCell(new ConfigCellSelectBox(null, NekoConfig.actionBarDecoration, new String[]{

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
@@ -206,7 +206,6 @@ private final AbstractConfigCell defaultHlsVideoQualityRow = cellGroup.appendCel
     private final AbstractConfigCell typefaceRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.typeface));
     private final AbstractConfigCell transparentStatusBarRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.transparentStatusBar));
     private final AbstractConfigCell appBarShadowRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.disableAppBarShadow));
-    private final AbstractConfigCell strokeOnViewsRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getStrokeOnViews()));
     private final AbstractConfigCell newYearRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.newYear));
     private final AbstractConfigCell alwaysShowDownloadIconRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getAlwaysShowDownloadIcon()));
     private final AbstractConfigCell actionBarDecorationRow = cellGroup.appendCell(new ConfigCellSelectBox(null, NekoConfig.actionBarDecoration, new String[]{
@@ -315,6 +314,11 @@ private final AbstractConfigCell defaultHlsVideoQualityRow = cellGroup.appendCel
     private final AbstractConfigCell win32Row = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.disableAutoDownloadingWin32Executable));
     private final AbstractConfigCell archiveRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.disableAutoDownloadingArchive));
     private final AbstractConfigCell dividerAutoDownload = cellGroup.appendCell(new ConfigCellDivider());
+
+    // blur
+    private final AbstractConfigCell headerBlur = cellGroup.appendCell(new ConfigCellHeader(LocaleController.getString(R.string.LiteOptionsBlur2)));
+    private final AbstractConfigCell disableGlareEffectsRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getDisableGlareEffects()));
+    private final AbstractConfigCell dividerBlur = cellGroup.appendCell(new ConfigCellDivider());
 
     private ChatBlurAlphaSeekBar chatBlurAlphaSeekbar;
 

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -1319,6 +1319,12 @@ object NaConfig {
             ConfigItem.configTypeBool,
             false
         )
+    val strokeOnViews =
+        addConfig(
+            "StrokeOnViews",
+            ConfigItem.configTypeBool,
+            true
+        )
 
     private fun addConfig(
         k: String,

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -1319,11 +1319,11 @@ object NaConfig {
             ConfigItem.configTypeBool,
             false
         )
-    val strokeOnViews =
+    val disableGlareEffects =
         addConfig(
-            "StrokeOnViews",
+            "DisableGlareEffects",
             ConfigItem.configTypeBool,
-            true
+            false
         )
 
     private fun addConfig(

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
@@ -348,4 +348,5 @@
     <string name="ShowRecentForwardTab">转发时显示最近会话</string>
     <string name="ProviderVolcengineTranslate">火山引擎</string>
     <string name="DisableAiEditor">禁用 AI 编辑器</string>
+    <string name="DisableGlareEffects">禁用炫光效果</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -349,5 +349,5 @@
     <string name="ShowRecentForwardTab">Show recent chats tab when forwarding</string>
     <string name="ProviderVolcengineTranslate">Volcengine Translate</string>
     <string name="DisableAiEditor">Disable Ai Editor</string>
-    <string name="StrokeOnViews">Glare effects</string>
+    <string name="DisableGlareEffects">Disable Glare effects</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -349,4 +349,5 @@
     <string name="ShowRecentForwardTab">Show recent chats tab when forwarding</string>
     <string name="ProviderVolcengineTranslate">Volcengine Translate</string>
     <string name="DisableAiEditor">Disable Ai Editor</string>
+    <string name="StrokeOnViews">Glare effects</string>
 </resources>


### PR DESCRIPTION
hello there, i personally don't like the glare effects. so i added a option to turn it off.

https://github.com/Nekogram/Nekogram/commit/74109478c7fcbb529f756628aeba9fb44bafe2e9
https://github.com/Nekogram/Nekogram/commit/43fe6a8db518a2a9fa57c1fb96c7aa2a5a5776d8

## Summary by Sourcery

Add a configurable option to disable glare-style stroke effects on blurred backgrounds and related UI views.

New Features:
- Introduce a StrokeOnViews boolean configuration flag that controls rendering of glare stroke effects on views.
- Expose the StrokeOnViews option in the general settings UI for user control, labeled as "Glare effects".

Enhancements:
- Wire the StrokeOnViews configuration into blurred background drawing logic to conditionally skip stroke rendering and associated nine-patch handling.