### PR TITLE
feat: show forwards count

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -1762,6 +1762,10 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
     private int viewsTextWidth;
     private String currentViewsString;
 
+    private StaticLayout forwardsLayout;
+    private int forwardsTextWidth;
+    private String currentForwardsString;
+
     private StaticLayout repliesLayout;
     private int repliesTextWidth;
     private String currentRepliesString;
@@ -13925,6 +13929,12 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 viewsLayout = null;
             }
 
+            if (currentForwardsString != null) {
+                forwardsLayout = new StaticLayout(currentForwardsString, Theme.chat_timePaint, forwardsTextWidth, Layout.Alignment.ALIGN_NORMAL, 1.0f, 0.0f, false);
+            } else {
+                forwardsLayout = null;
+            }
+
             if (currentRepliesString != null && !currentMessageObject.scheduled) {
                 repliesLayout = new StaticLayout(currentRepliesString, Theme.chat_timePaint, repliesTextWidth, Layout.Alignment.ALIGN_NORMAL, 1.0f, 0.0f, false);
             } else {
@@ -18618,6 +18628,18 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             viewsTextWidth = (int) Math.ceil(Theme.chat_timePaint.measureText(currentViewsString));
             float drawableWidth = Theme.chat_msgInViewsDrawable.getIntrinsicWidth() * (Theme.chat_timePaint.getTextSize() - dp(2)) / Theme.chat_msgInViewsDrawable.getIntrinsicHeight();
             timeWidth += viewsTextWidth + drawableWidth + dp(10);
+        } else {
+            currentViewsString = null;
+            viewsTextWidth = 0;
+        }
+        if (messageObject.messageOwner.forwards > 0) {
+            currentForwardsString = String.format("%s", LocaleController.formatShortNumber(Math.max(1, messageObject.messageOwner.forwards), null));
+            forwardsTextWidth = (int) Math.ceil(Theme.chat_timePaint.measureText(currentForwardsString));
+            float drawableWidth = TimeStringHelper.forwardsDrawable != null ? (TimeStringHelper.forwardsDrawable.getIntrinsicWidth() * (Theme.chat_timePaint.getTextSize() - dp(2)) / Math.max(1f, TimeStringHelper.forwardsDrawable.getIntrinsicHeight())) : 0;
+            timeWidth += forwardsTextWidth + drawableWidth + dp(10);
+        } else {
+            currentForwardsString = null;
+            forwardsTextWidth = 0;
         }
         if (messageObject.type == MessageObject.TYPE_EXTENDED_MEDIA_PREVIEW) {
             String str = formatString(R.string.PaymentCheckoutPay, LocaleController.getInstance().formatCurrencyString(messageObject.messageOwner.media.total_amount, messageObject.messageOwner.media.currency).toUpperCase(Locale.ROOT));
@@ -24609,6 +24631,53 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             }
             transitionParams.lastTimeXViews = viewsX;
         }
+        // Forwards count start
+        if (forwardsLayout != null) {
+            float forwardsX = (transitionParams.shouldAnimateTimeX ? this.timeX : timeX) + offsetX;
+            if (!(isRoundVideo && transitionParams.animateDrawBackground)) {
+                if (transitionParams.shouldAnimateTimeX) {
+                    forwardsX = transitionParams.animateFromTimeXViews * (1f - transitionParams.animateChangeProgress) + forwardsX * transitionParams.animateChangeProgress;
+                }
+            }
+            if (currentMessagesGroup != null && currentMessagesGroup.transitionParams.backgroundChangeBounds) {
+                forwardsX += currentMessagesGroup.transitionParams.offsetRight;
+            }
+            if (transitionParams.animateBackgroundBoundsInner) {
+                forwardsX += animationOffsetX;
+            }
+            Drawable forwardsDrawable = TimeStringHelper.forwardsDrawable;
+            if (forwardsDrawable == null) {
+                try {
+                    TimeStringHelper.forwardsDrawable = ContextCompat.getDrawable(ApplicationLoader.applicationContext, R.drawable.forwards_solar).mutate();
+                    forwardsDrawable = TimeStringHelper.forwardsDrawable;
+                } catch (Exception ignore) {}
+            }
+            float fw = 0;
+            if (forwardsDrawable != null) {
+                int color = Theme.chat_timePaint.getColor();
+                forwardsDrawable.setColorFilter(new PorterDuffColorFilter(color, PorterDuff.Mode.SRC_IN));
+                fw = setDrawableBounds(forwardsDrawable, forwardsX, timeY + dp(1.5f), Theme.chat_timePaint.getTextSize() - dp(2));
+                if (useScale) {
+                    canvas.save();
+                    float cx = forwardsX + (forwardsDrawable.getIntrinsicWidth() + dp(3) + forwardsTextWidth) / 2f;
+                    canvas.scale(scale, scale, cx, forwardsDrawable.getBounds().centerY());
+                }
+                forwardsDrawable.setAlpha((int) (255 * alpha));
+                forwardsDrawable.draw(canvas);
+                forwardsDrawable.setAlpha(255);
+                forwardsDrawable.setColorFilter(null);
+            }
+
+            canvas.save();
+            canvas.translate(forwardsX + fw + dp(3), timeY);
+            SpoilerEffect.layoutDrawMaybe(forwardsLayout, canvas);
+            canvas.restore();
+            if (useScale && forwardsDrawable != null) {
+                canvas.restore();
+            }
+            offsetX += forwardsTextWidth + fw + dp(10);
+        }
+        // Forwards count end
         if (isPinned || transitionParams.animatePinned) {
             float pinnedX = (transitionParams.shouldAnimateTimeX ? this.timeX : timeX) + offsetX;
             boolean inAnimation = transitionParams.animatePinned && isPinned;

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/TimeStringHelper.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/TimeStringHelper.java
@@ -4,6 +4,7 @@ import static org.telegram.messenger.AndroidUtilities.dp;
 
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.graphics.drawable.Drawable;
 import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
@@ -13,12 +14,21 @@ import android.view.Gravity;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 
 import org.telegram.messenger.AndroidUtilities;
+import org.telegram.messenger.ApplicationLoader;
+import org.telegram.messenger.R;
 import org.telegram.messenger.SharedConfig;
 import org.telegram.ui.Components.AnimatedTextView;
+import org.telegram.ui.Components.ColoredImageSpan;
+
+import java.util.Objects;
 
 public class TimeStringHelper {
+    public static SpannableStringBuilder forwardsSpan;
+    public static Drawable forwardsDrawable;
+
     public static CharSequence getColoredAdminString(View parent, TextPaint namePaint, SpannableStringBuilder sb) {
         SpannableString spannableString = new SpannableString("\u200B");
         spannableString.setSpan(new adminStringSpan(parent, namePaint, sb), 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
@@ -39,6 +49,14 @@ public class TimeStringHelper {
             adminString.setText("");
             adminString.setGravity(Gravity.CENTER);
             setText(sb, false);
+
+            if (forwardsDrawable == null) {
+                forwardsDrawable = Objects.requireNonNull(ContextCompat.getDrawable(ApplicationLoader.applicationContext, R.drawable.forwards_solar)).mutate();
+            }
+            if (forwardsSpan == null) {
+                forwardsSpan = new SpannableStringBuilder("\u200B");
+                forwardsSpan.setSpan(new ColoredImageSpan(forwardsDrawable, ColoredImageSpan.ALIGN_CENTER), 0, 1, 0);
+            }
         }
 
         public void setText(SpannableStringBuilder sb, boolean animated) {

--- a/TMessagesProj/src/main/res/drawable/forwards_solar.xml
+++ b/TMessagesProj/src/main/res/drawable/forwards_solar.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="12dp"
+    android:viewportWidth="12"
+    android:viewportHeight="12">
+    <path
+        android:fillColor="#FFF"
+        android:pathData="M7.07 2.3L10 4.7c0.55 0.45 0.82 0.68 0.92 0.94 0.1 0.23 0.1 0.49 0 0.72-0.1 0.26-0.37 0.49-0.92 0.94L7.07 9.7C6.82 9.9 6.69 10 6.59 10c-0.1 0-0.18-0.03-0.24-0.1-0.07-0.07-0.07-0.23-0.07-0.53V7.86c-1.43 0-2.95 0.42-4.05 1.17C1.65 9.42 1.36 9.6 1.25 9.6 1.15 9.6 1.08 9.56 1.02 9.48c-0.05-0.09 0-0.36 0.1-0.9 0.65-3.5 3.28-4.44 5.16-4.44v-1.5c0-0.31 0-0.47 0.07-0.54C6.4 2.03 6.5 2 6.59 2c0.1 0 0.23 0.1 0.48 0.3Z"/>
+</vector>


### PR DESCRIPTION
Thanks to @NagramX, @Cherrygram.

https://github.com/risin42/NagramX/commit/075d5cb5aaf660142188284a6948908da7521c2c

## Summary by Sourcery

Display message forwards count with an icon alongside existing metadata in chat cells.

New Features:
- Add forwards count text and icon to message time/metadata area when a message has been forwarded.
- Introduce a new forwards vector drawable for use in chat message UI.

Enhancements:
- Extend time measurement and layout logic in chat cells to account for forwards count width and positioning.
- Cache and reuse a tinted forwards icon span via TimeStringHelper for consistent rendering.