### PR TITLE
fix: hide media cache from gallery

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/ImageLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ImageLoader.java
@@ -2398,6 +2398,7 @@ public class ImageLoader {
                     File imagePath = new File(telegramPath, "images");
                     FileUtil.initDir(imagePath);
                     if (imagePath.isDirectory() && canMoveFiles(cachePath, imagePath, FileLoader.MEDIA_DIR_IMAGE)) {
+                        AndroidUtilities.createEmptyFile(new File(imagePath, ".nomedia"));
                         mediaDirs.put(FileLoader.MEDIA_DIR_IMAGE, imagePath);
                         if (BuildVars.LOGS_ENABLED) {
                             FileLog.d("image path = " + imagePath);
@@ -2411,6 +2412,7 @@ public class ImageLoader {
                     File videoPath = new File(telegramPath, "videos");
                     FileUtil.initDir(videoPath);
                     if (videoPath.isDirectory() && canMoveFiles(cachePath, videoPath, FileLoader.MEDIA_DIR_VIDEO)) {
+                        AndroidUtilities.createEmptyFile(new File(videoPath, ".nomedia"));
                         mediaDirs.put(FileLoader.MEDIA_DIR_VIDEO, videoPath);
                         if (BuildVars.LOGS_ENABLED) {
                             FileLog.d("video path = " + videoPath);


### PR DESCRIPTION
for some weird reason, telegram stock doesn't do this. i found it annoying when i see the media cache in my gallery.

thanks to @uzbekreleases