### PR TITLE
fix: Skip camera permission if Disable Instant Camera is true

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPhotoLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPhotoLayout.java
@@ -3948,7 +3948,7 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
     }
 
     public void setCheckCameraWhenShown(boolean checkCameraWhenShown) {
-        this.checkCameraWhenShown = checkCameraWhenShown;
+        this.checkCameraWhenShown = checkCameraWhenShown && !NekoConfig.disableInstantCamera.Bool();
     }
 
     @Override
@@ -4164,7 +4164,7 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
 
     @Override
     public void onOpenAnimationEnd() {
-        checkCamera(parentAlert != null && parentAlert.baseFragment instanceof ChatActivity);
+        checkCamera(parentAlert != null && parentAlert.baseFragment instanceof ChatActivity && !NekoConfig.disableInstantCamera.Bool());
     }
 
     @Override


### PR DESCRIPTION
Hi, I found it annoying, if I have Disable Instant Camera enabled, and it asks me to grant camera permission for just opening the gallery.

## Summary by Sourcery

Bug Fixes:
- Prevent camera permission checks when the Disable Instant Camera setting is enabled, allowing the gallery to open without requesting unnecessary camera access.