### PR TITLE
feat: clear cloud settings data

### DIFF
--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/CloudSettingsHelper.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/CloudSettingsHelper.java
@@ -35,6 +35,7 @@ import org.telegram.ui.Components.ScaleStateListAnimator;
 import org.telegram.ui.Components.TextViewSwitcher;
 import org.telegram.ui.Stories.recorder.ButtonWithCounterView;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicReference;
@@ -156,6 +157,26 @@ public class CloudSettingsHelper {
             });
         });
 
+        ButtonWithCounterView deleteButton = new ButtonWithCounterView(context, false, resourcesProvider).setRound();
+        deleteButton.setText(LocaleController.getString(R.string.DeleteCloudBackup), false);
+        deleteButton.setTextColor(Theme.getColor(Theme.key_dialogTextRed));
+        linearLayout.addView(deleteButton, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, 48, 16, 8, 16, 0));
+        deleteButton.setOnClickListener(view -> {
+            syncedDate.setText(AndroidUtilities.replaceTags(LocaleController.formatString(R.string.CloudConfigSyncing)));
+            deleteCloudBackup((success, error) -> {
+                syncedDate.setText(formatSyncedDate());
+                if (!success) {
+                    if (error == null) {
+                        BulletinFactory.of(Bulletin.BulletinWindow.make(context), resourcesProvider).createSimpleBulletin(R.raw.info, LocaleController.getString(R.string.CloudConfigNoBackupToDelete)).show();
+                    } else {
+                        BulletinFactory.of(Bulletin.BulletinWindow.make(context), resourcesProvider).createSimpleBulletin(R.raw.error, LocaleController.getString(R.string.DeleteCloudBackupFailed), error).show();
+                    }
+                } else {
+                    BulletinFactory.of(Bulletin.BulletinWindow.make(context), resourcesProvider).createSimpleBulletin(R.raw.done, LocaleController.getString(R.string.DeleteCloudBackupSuccess)).show();
+                }
+            });
+        });
+
         MiniCheckBoxCell autoSyncCheck = new MiniCheckBoxCell(context, 8, resourcesProvider);
         autoSyncCheck.setTextAndValueAndCheck(LocaleController.getString("CloudConfigAutoSync", R.string.CloudConfigAutoSync), LocaleController.getString("CloudConfigAutoSyncDesc", R.string.CloudConfigAutoSyncDesc), autoSync);
         autoSyncCheck.setOnClickListener(view13 -> {
@@ -255,6 +276,40 @@ public class CloudSettingsHelper {
             } else {
                 callback.run(false, error);
             }
+        });
+    }
+
+    private void deleteCloudBackup(Utilities.Callback2<Boolean, String> callback) {
+        getCloudStorageHelper().getKeys((keys, error) -> {
+            if (error != null) {
+                callback.run(false, error);
+                return;
+            }
+            if (keys == null || keys.length == 0) {
+                callback.run(false, null);
+                return;
+            }
+
+            ArrayList<String> nekoKeys = new ArrayList<>();
+            for (String key : keys) {
+                if (key.startsWith("neko_settings")) {
+                    nekoKeys.add(key);
+                }
+            }
+
+            if (nekoKeys.isEmpty()) {
+                callback.run(false, null);
+                return;
+            }
+
+            getCloudStorageHelper().removeItems(nekoKeys.toArray(new String[0]), (res_, error_) -> {
+                if (error_ == null) {
+                    cloudSyncedDate.put(UserConfig.selectedAccount, -1L);
+                    callback.run(true, null);
+                } else {
+                    callback.run(false, error_);
+                }
+            });
         });
     }
 

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
@@ -350,4 +350,8 @@
     <string name="DisableAiEditor">禁用 AI 编辑器</string>
     <string name="DisableGlareEffects">禁用炫光效果</string>
     <string name="ShowEditedIcon">显示图标而不是 \"已编辑\"</string>
+    <string name="DeleteCloudBackup">清除云数据</string>
+    <string name="DeleteCloudBackupFailed">云备份数据清除失败</string>
+    <string name="DeleteCloudBackupSuccess">云备份数据已清除</string>
+    <string name="CloudConfigNoBackupToDelete">没有数据可清除</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -351,4 +351,8 @@
     <string name="DisableAiEditor">Disable Ai Editor</string>
     <string name="DisableGlareEffects">Disable Glare effects</string>
     <string name="ShowEditedIcon">Show icon instead of \"edited\"</string>
+    <string name="DeleteCloudBackup">Clear cloud data</string>
+    <string name="DeleteCloudBackupFailed">Failed to clear cloud data</string>
+    <string name="DeleteCloudBackupSuccess">Cloud data cleared</string>
+    <string name="CloudConfigNoBackupToDelete">No data to clear</string>
 </resources>


### PR DESCRIPTION
hi, it would be great if we provide an option for the user to clear cloud settings. for example the user doesn't want their settings to be in the cloud

thanks to @NagramX

## Summary by Sourcery

Enable users to remove their Nekogram settings backup from cloud storage.

New Features:
- Add an option to clear the user's cloud-stored settings data.

Enhancements:
- Provide user feedback for successful deletion, missing data, and deletion failures while updating cloud sync status.

Chores:
- Add localized strings for cloud data deletion actions and status messages in English and Simplified Chinese.