### PR TITLE
chore: disable instant camera by default

### DIFF
--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoConfig.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoConfig.java
@@ -48,7 +48,7 @@ public class NekoConfig {
     public static ConfigItem update_download_soucre = addConfig("update_download_soucre", configTypeInt, 0); // 0: Github 1: Channel 2:CDNDrive, removed
     public static ConfigItem useCustomEmoji = addConfig("useCustomEmoji", configTypeBool, false);
     public static ConfigItem repeatConfirm = addConfig("repeatConfirm", configTypeBool, false);
-    public static ConfigItem disableInstantCamera = addConfig("DisableInstantCamera", configTypeBool, false);
+    public static ConfigItem disableInstantCamera = addConfig("DisableInstantCamera", configTypeBool, true);
     public static ConfigItem showSeconds = addConfig("showSeconds", configTypeBool, false);
 
     public static ConfigItem enablePublicProxy = addConfig("enablePublicProxy", configTypeBool, true);


### PR DESCRIPTION
hi, i think 90% of users find this annoying by default, so i made this enabled by default. the user could disable it in the settings.

## Summary by Sourcery

Enhancements:
- Disable the instant camera feature by default while preserving the option to re-enable it in settings.
