### PR TITLE
feat: show mini sender avatar

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogCell.java
@@ -211,6 +211,8 @@ public class DialogCell extends BaseCell implements StoriesListPlaceProvider.Ava
     public boolean isSavedDialogCell;
     public DialogCellTags tags;
 
+    private final AvatarSpan senderAvatarSpan;
+
     public final StoriesUtilities.AvatarStoryParams storyParams = new StoriesUtilities.AvatarStoryParams(false) {
         @Override
         public boolean isAvatarClickable(long dialogId, TLRPC.Chat chat, TLRPC.User user) {
@@ -724,6 +726,8 @@ public class DialogCell extends BaseCell implements StoriesListPlaceProvider.Ava
         emojiStatus = new AnimatedEmojiDrawable.SwapAnimatedEmojiDrawable(emojiStatusView, dp(22));
         botVerification = new AnimatedEmojiDrawable.SwapAnimatedEmojiDrawable(this, dp(17));
         avatarImage.setAllowLoadingOnAttachedOnly(true);
+        senderAvatarSpan = new AvatarSpan(this, currentAccount);
+        senderAvatarSpan.needDrawShadow = false;
         avatarGroupSenderImage.setAllowLoadingOnAttachedOnly(true);
     }
 
@@ -1817,6 +1821,7 @@ public class DialogCell extends BaseCell implements StoriesListPlaceProvider.Ava
                                 user != null && user.id == UserObject.VERIFY && message != null && message.getForwardedFromId() != null
                             ) {
                                 messageNameString = AndroidUtilities.escape(triedMessageName != null ? triedMessageName : getMessageNameString());
+                                messageNameString = addSenderAvatar(messageNameString, message);
                                 if (chat != null && chat.forum && !isTopic && !useFromUserAsAvatar) {
                                     CharSequence topicName = MessagesController.getInstance(currentAccount).getTopicsController().getTopicIconName(chat, message, currentMessagePaint);
                                     if (!TextUtils.isEmpty(topicName)) {
@@ -2985,6 +2990,20 @@ public class DialogCell extends BaseCell implements StoriesListPlaceProvider.Ava
             }
         }
         updateThumbsPosition();
+    }
+
+    private CharSequence addSenderAvatar(CharSequence messageNameString, MessageObject message) {
+        if (NaConfig.INSTANCE.getShowMiniSenderAvatar().Bool() && !TextUtils.isEmpty(messageNameString)) {
+            var fromChatId = message.getFromChatId();
+            if (fromChatId != UserConfig.getInstance(currentAccount).getClientUserId()) {
+                var builder = new SpannableStringBuilder("\u200B ");
+                senderAvatarSpan.setDialogId(fromChatId);
+                builder.setSpan(senderAvatarSpan, 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+                builder.append(messageNameString);
+                return builder;
+            }
+        }
+        return messageNameString;
     }
 
     public void setTitleOverride(String s) {

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
@@ -80,6 +80,7 @@ public class NekoGeneralSettingsActivity extends BaseNekoXSettingsActivity {
     private final CellGroup a = cellGroup = new CellGroup(this);
 
     private final AbstractConfigCell showSquareAvatarRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getShowSquareAvatar()));
+    private final AbstractConfigCell showMiniSenderAvatarRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getShowMiniSenderAvatar()));
     private final AbstractConfigCell disableProfileAvatarBlurRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getDisableProfileAvatarBlur()));
     private final AbstractConfigCell disableGooeyAvatarAnimationRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getDisableGooeyAvatarAnimation()));
     private final AbstractConfigCell hidePhoneRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.hidePhone));

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -1349,6 +1349,12 @@ object NaConfig {
             ConfigItem.configTypeBool,
             false
         )
+    val showMiniSenderAvatar =
+        addConfig(
+            "ShowMiniSenderAvatar",
+            ConfigItem.configTypeBool,
+            false
+        )
 
     private fun addConfig(
         k: String,

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -358,4 +358,5 @@
     <string name="LiquidGlassAngle">Liquid Glass angle</string>
     <string name="LiquidGlassIntensity">Liquid Glass intensity</string>
     <string name="DisableGooeyAvatarAnimation">Disable \"Gooey\" avatar animation</string>
+    <string name="ShowMiniSenderAvatar">Show Mini Sender Avatar</string>
 </resources>


### PR DESCRIPTION
thanks to @nekogram

https://github.com/Nekogram/Nekogram/commit/739ac675c156588e2d8795ca7ed0c83bca877fb9

## Summary by Sourcery

Add configurable mini sender avatars to dialog message previews.

New Features:
- Add an optional mini avatar beside sender names in dialog message previews.
- Expose a general setting for enabling mini sender avatars.