### PR TITLE
style: replace instant camera tile with floating button

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPhotoLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPhotoLayout.java
@@ -750,10 +750,9 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
         return arrayList;
     }
 
-    public ChatAttachAlertPhotoLayout(ChatAttachAlert alert, Context context, boolean forceDarkTheme, boolean needCamera_, Theme.ResourcesProvider resourcesProvider) {
+    public ChatAttachAlertPhotoLayout(ChatAttachAlert alert, Context context, boolean forceDarkTheme, boolean needCamera, Theme.ResourcesProvider resourcesProvider) {
         super(alert, context, resourcesProvider);
         this.forceDarkTheme = forceDarkTheme;
-        boolean needCamera = needCamera_ && !NaConfig.INSTANCE.getHideInstantCamera().Bool();
         this.needCamera = needCamera;
         NotificationCenter.getGlobalInstance().addObserver(this, NotificationCenter.albumsDidLoad);
         NotificationCenter.getGlobalInstance().addObserver(this, NotificationCenter.cameraInitied);
@@ -841,7 +840,7 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
         gridView.getFastScroll().setAlpha(0f);
         gridView.getFastScroll().usePadding = false;
         gridView.getFastScroll().topOffset = ActionBar.getCurrentActionBarHeight(); // + AndroidUtilities.statusBarHeight;
-        gridView.setAdapter(adapter = new PhotoAttachAdapter(context, !NekoConfig.disableInstantCamera.Bool() && needCamera));
+        gridView.setAdapter(adapter = new PhotoAttachAdapter(context, !NaConfig.INSTANCE.getHideInstantCamera().Bool() && needCamera));
         gridView.addItemDecoration(cameraViewItemDecoration = new CameraViewItemDecoration(gridView));
         adapter.createCache();
         gridView.setClipToPadding(false);
@@ -1159,7 +1158,7 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
             progressView.showTextView();
         }
 
-        if (needCamera && NekoConfig.disableInstantCamera.Bool()) {
+        if (needCamera && NaConfig.INSTANCE.getHideInstantCamera().Bool()) {
             cameraFloatingButton = new FragmentFloatingButton(getContext(), resourcesProvider);
             cameraFloatingButton.setContentDescription(LocaleController.getString(R.string.AccDescrInstantCamera));
             cameraFloatingButton.setImageResource(R.drawable.camera);
@@ -2599,14 +2598,14 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
         AndroidUtilities.setLightNavigationBar(parentAlert, false);
         parentAlert.getWindow().addFlags(FLAG_KEEP_SCREEN_ON);
         if (animated) {
-            setCameraOpenProgress(NekoConfig.disableInstantCamera.Bool() ? 1f : 0);
+            setCameraOpenProgress(NaConfig.INSTANCE.getHideInstantCamera().Bool() ? 1f : 0);
             cameraAnimationInProgress = true;
             if (gridView != null) {
                 gridView.invalidate();
             }
             notificationsLocker.lock();
             ArrayList<Animator> animators = new ArrayList<>();
-            if (!NekoConfig.disableInstantCamera.Bool()) {
+            if (!NaConfig.INSTANCE.getHideInstantCamera().Bool()) {
                 animators.add(ObjectAnimator.ofFloat(this, "cameraOpenProgress", 0.0f, 1.0f));
             } else if (cameraView.isInited()) {
                 animators.add(ObjectAnimator.ofFloat(cameraView, View.ALPHA, 0.0f, 1.0f));
@@ -2969,7 +2968,7 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
                 gridView.invalidate();
             }
             ArrayList<Animator> animators = new ArrayList<>();
-            if (!NekoConfig.disableInstantCamera.Bool()) {
+            if (!NaConfig.INSTANCE.getHideInstantCamera().Bool()) {
                 animators.add(ObjectAnimator.ofFloat(this, "cameraOpenProgress", 0.0f));
             } else {
                 animators.add(ObjectAnimator.ofFloat(cameraView, View.ALPHA, 0.0f));

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPhotoLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPhotoLayout.java
@@ -159,6 +159,7 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
     private GridLayoutManager layoutManager;
     private PhotoAttachAdapter adapter;
     private EmptyTextProgressView progressView;
+    private FragmentFloatingButton cameraFloatingButton;
     private RecyclerViewItemRangeSelector itemRangeSelector;
     private int gridExtraSpace;
     private boolean shouldSelect;
@@ -840,7 +841,7 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
         gridView.getFastScroll().setAlpha(0f);
         gridView.getFastScroll().usePadding = false;
         gridView.getFastScroll().topOffset = ActionBar.getCurrentActionBarHeight(); // + AndroidUtilities.statusBarHeight;
-        gridView.setAdapter(adapter = new PhotoAttachAdapter(context, needCamera));
+        gridView.setAdapter(adapter = new PhotoAttachAdapter(context, !NekoConfig.disableInstantCamera.Bool() && needCamera));
         gridView.addItemDecoration(cameraViewItemDecoration = new CameraViewItemDecoration(gridView));
         adapter.createCache();
         gridView.setClipToPadding(false);
@@ -914,10 +915,10 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
         layoutManager.setSpanSizeLookup(new GridLayoutManager.SpanSizeLookup() {
             @Override
             public int getSpanSize(int position) {
-                if (position == adapter.itemsCount - 1 || (noGalleryPermissions || noCameraPermissions) && position == 0) {
+                if (position == adapter.itemsCount - 1 || (noGalleryPermissions || (adapter.needCamera && selectedAlbumEntry == galleryAlbumEntry && noCameraPermissions)) && position == 0) {
                     return layoutManager.getSpanCount();
                 }
-                if (noCameraPermissions) {
+                if (adapter.needCamera && selectedAlbumEntry == galleryAlbumEntry && noCameraPermissions) {
                     position--;
                 }
                 return itemSize + (position % itemsPerRow != itemsPerRow - 1 ? dp(GAP) : 0);
@@ -968,11 +969,11 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
                 return;
             }
 
-            if (position != 0 || !needCamera || selectedAlbumEntry != galleryAlbumEntry) {
+            if (position != 0 || !adapter.needCamera || selectedAlbumEntry != galleryAlbumEntry) {
                 if (adapter.hasCameraSpaceRow && position > itemsPerRow) {
                     position--;
                 }
-                if (selectedAlbumEntry == galleryAlbumEntry && needCamera) {
+                if (selectedAlbumEntry == galleryAlbumEntry && adapter.needCamera) {
                     position--;
                 }
                 if (showAvatarConstructor) {
@@ -1156,6 +1157,21 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
             progressView.showProgress();
         } else {
             progressView.showTextView();
+        }
+
+        if (needCamera && NekoConfig.disableInstantCamera.Bool()) {
+            cameraFloatingButton = new FragmentFloatingButton(getContext(), resourcesProvider);
+            cameraFloatingButton.setContentDescription(LocaleController.getString(R.string.AccDescrInstantCamera));
+            cameraFloatingButton.setImageResource(R.drawable.camera);
+            cameraFloatingButton.setOnClickListener(view -> openCameraWithPermissionCheck());
+            cameraFloatingButton.setOnLongClickListener(view -> {
+                if (parentAlert.delegate != null) {
+                    parentAlert.delegate.didPressedButton(0, false, true, 0, 0, 0, parentAlert.isCaptionAbove(), false, 0);
+                    return true;
+                }
+                return false;
+            });
+            addView(cameraFloatingButton, FragmentFloatingButton.createDefaultLayoutParams());
         }
 
         Paint recordPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
@@ -1608,6 +1624,21 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
             if (parentAlert.delegate != null) {
                 parentAlert.delegate.didPressedButton(0, false, true, 0, 0, 0, parentAlert.isCaptionAbove(), false, 0);
             }
+        }
+    }
+
+    public void updateCameraButton() {
+        if (cameraFloatingButton == null) return;
+        var show = getSelectedItemsCount() == 0;
+        if (show) {
+            var typeButtons = parentAlert.buttonsRecyclerViewWrapper;
+            var progress = typeButtons.getVisibility() != VISIBLE ? 0f : typeButtons.getAlpha();
+            var offsetY = progress * parentAlert.getTypeButtonsHeight() + AndroidUtilities.navigationBarHeight;
+            cameraFloatingButton.setTranslationY(-offsetY);
+        }
+        var currentlyVisible = cameraFloatingButton.getButtonVisible();
+        if (currentlyVisible != show) {
+            cameraFloatingButton.setButtonVisible(show, true);
         }
     }
 
@@ -2568,14 +2599,18 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
         AndroidUtilities.setLightNavigationBar(parentAlert, false);
         parentAlert.getWindow().addFlags(FLAG_KEEP_SCREEN_ON);
         if (animated) {
-            setCameraOpenProgress(0);
+            setCameraOpenProgress(NekoConfig.disableInstantCamera.Bool() ? 1f : 0);
             cameraAnimationInProgress = true;
             if (gridView != null) {
                 gridView.invalidate();
             }
             notificationsLocker.lock();
             ArrayList<Animator> animators = new ArrayList<>();
-            animators.add(ObjectAnimator.ofFloat(this, "cameraOpenProgress", 0.0f, 1.0f));
+            if (!NekoConfig.disableInstantCamera.Bool()) {
+                animators.add(ObjectAnimator.ofFloat(this, "cameraOpenProgress", 0.0f, 1.0f));
+            } else if (cameraView.isInited()) {
+                animators.add(ObjectAnimator.ofFloat(cameraView, View.ALPHA, 0.0f, 1.0f));
+            }
             animators.add(ObjectAnimator.ofFloat(cameraPanel, View.ALPHA, 1.0f));
             animators.add(ObjectAnimator.ofFloat(counterTextView, View.ALPHA, 1.0f));
             animators.add(ObjectAnimator.ofFloat(cameraPhotoRecyclerView, View.ALPHA, 1.0f));
@@ -2934,7 +2969,11 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
                 gridView.invalidate();
             }
             ArrayList<Animator> animators = new ArrayList<>();
-            animators.add(ObjectAnimator.ofFloat(this, "cameraOpenProgress", 0.0f));
+            if (!NekoConfig.disableInstantCamera.Bool()) {
+                animators.add(ObjectAnimator.ofFloat(this, "cameraOpenProgress", 0.0f));
+            } else {
+                animators.add(ObjectAnimator.ofFloat(cameraView, View.ALPHA, 0.0f));
+            }
             animators.add(ObjectAnimator.ofFloat(cameraPanel, View.ALPHA, 0.0f));
             animators.add(ObjectAnimator.ofFloat(zoomControlView, View.ALPHA, 0.0f));
             animators.add(ObjectAnimator.ofFloat(counterTextView, View.ALPHA, 0.0f));
@@ -3642,6 +3681,7 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
         } else {
             parentAlert.selectedMenuItem.hideSubItem(stars);
         }
+        updateCameraButton();
     }
 
     private void updateStarsItem() {
@@ -3874,6 +3914,7 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
     @Override
     public void onButtonsTranslationYUpdated() {
         checkCameraViewPosition();
+        updateCameraButton();
         invalidate();
     }
 


### PR DESCRIPTION
hi, i think floating button looks better than the instant camera.

thanks to @nekoupdates

https://github.com/Nekogram/Nekogram/commit/b2181c3a241e8dd5478176bf9780a1214d64b85c

verification:
it compiles successfully.
couldn't launch the app due to [signature check](https://github.com/NextAlone/Nagram/commit/01cf252b0be0934299a1fdd7e042b6102c162c30) to check if it works as expected, I have no idea how to generate the files due to an refactor (README is outdated).

## Summary by Sourcery

Add a configurable floating camera button to the attachment picker while retaining compatibility with the instant camera option.

New Features:
- Replace the instant camera tile in the attachment picker with an optional floating camera button.
- Support camera button interactions for opening the camera and long-pressing to trigger the existing camera action.

Enhancements:
- Update camera button visibility and positioning as attachment selection and action controls change.
- Adapt camera opening and closing animations for the floating-button camera experience while preserving the existing instant-camera behavior when enabled.