### PR TITLE
style: adapt colorful icons to Monet themes

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
@@ -6564,11 +6564,15 @@ public class Theme {
         return resourcesProvider != null ? resourcesProvider.isMonet() : isCurrentThemeMonet();
     }
 
-    public static void applyThemeMonetColor(ImageView view, ResourcesProvider resourcesProvider) {
-        if (!Theme.isCurrentThemeMonet(resourcesProvider)) {
+    public static void applyThemeMonetColor(ImageView view, ResourcesProvider resourcesProvider, boolean white) {
+        if (view == null) {
             return;
         }
-        view.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_chats_actionIcon, resourcesProvider), PorterDuff.Mode.SRC_IN));
+        if (Theme.isCurrentThemeMonet(resourcesProvider)) {
+            view.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_chats_actionIcon, resourcesProvider), PorterDuff.Mode.SRC_IN));
+        } else if (white) {
+            view.setColorFilter(new PorterDuffColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN));
+        }
     }
 
     public static ThemeInfo getActiveTheme() {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
@@ -69,6 +69,7 @@ import android.util.SparseBooleanArray;
 import android.util.SparseIntArray;
 import android.util.StateSet;
 import android.view.View;
+import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -6561,6 +6562,13 @@ public class Theme {
 
     public static boolean isCurrentThemeMonet(ResourcesProvider resourcesProvider) {
         return resourcesProvider != null ? resourcesProvider.isMonet() : isCurrentThemeMonet();
+    }
+
+    public static void applyThemeMonetColor(ImageView view, ResourcesProvider resourcesProvider) {
+        if (!Theme.isCurrentThemeMonet(resourcesProvider)) {
+            return;
+        }
+        view.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_chats_actionIcon, resourcesProvider), PorterDuff.Mode.SRC_IN));
     }
 
     public static ThemeInfo getActiveTheme() {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
@@ -2155,6 +2155,10 @@ public class Theme {
             return Theme.isCurrentThemeDark();
         }
 
+        default boolean isMonet() {
+            return Theme.isCurrentThemeMonet();
+        }
+
         default void applyServiceShaderMatrix(int w, int h, float translationX, float translationY) {
             Theme.applyServiceShaderMatrix(w, h, translationX, translationY);
         }
@@ -6549,6 +6553,14 @@ public class Theme {
 
     public static boolean isCurrentThemeDark() {
         return currentTheme.isDark();
+    }
+
+    public static boolean isCurrentThemeMonet() {
+        return currentTheme.isMonet();
+    }
+
+    public static boolean isCurrentThemeMonet(ResourcesProvider resourcesProvider) {
+        return resourcesProvider != null ? resourcesProvider.isMonet() : isCurrentThemeMonet();
     }
 
     public static ThemeInfo getActiveTheme() {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/PollCreateCheckCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/PollCreateCheckCell.java
@@ -14,8 +14,6 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
-import android.graphics.PorterDuff;
-import android.graphics.PorterDuffColorFilter;
 import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -94,11 +92,7 @@ public class PollCreateCheckCell extends FrameLayout {
         drawable.setDrawBorder(border);
         imageView.setBackground(drawable);
         imageView.setImageResource(iconResId);
-        imageView.setColorFilter(new PorterDuffColorFilter(
-                Theme.isCurrentThemeMonet(resourcesProvider)
-                        ? Theme.getColor(Theme.key_chats_actionIcon, resourcesProvider)
-                        : 0xFFFFFFFF,
-                PorterDuff.Mode.SRC_IN));
+        Theme.applyThemeMonetColor(imageView, resourcesProvider);
         checkBox.setChecked(checked, 0, animationsEnabled);
         multilineValueTextView.setText(value);
         checkBox.setContentDescription(text);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/PollCreateCheckCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/PollCreateCheckCell.java
@@ -14,6 +14,8 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
 import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -92,6 +94,11 @@ public class PollCreateCheckCell extends FrameLayout {
         drawable.setDrawBorder(border);
         imageView.setBackground(drawable);
         imageView.setImageResource(iconResId);
+        imageView.setColorFilter(new PorterDuffColorFilter(
+                Theme.isCurrentThemeMonet(resourcesProvider)
+                        ? Theme.getColor(Theme.key_chats_actionIcon, resourcesProvider)
+                        : 0xFFFFFFFF,
+                PorterDuff.Mode.SRC_IN));
         checkBox.setChecked(checked, 0, animationsEnabled);
         multilineValueTextView.setText(value);
         checkBox.setContentDescription(text);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/PollCreateCheckCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/PollCreateCheckCell.java
@@ -92,7 +92,7 @@ public class PollCreateCheckCell extends FrameLayout {
         drawable.setDrawBorder(border);
         imageView.setBackground(drawable);
         imageView.setImageResource(iconResId);
-        Theme.applyThemeMonetColor(imageView, resourcesProvider);
+        Theme.applyThemeMonetColor(imageView, resourcesProvider, false);
         checkBox.setChecked(checked, 0, animationsEnabled);
         multilineValueTextView.setText(value);
         checkBox.setContentDescription(text);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/TextCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/TextCell.java
@@ -626,7 +626,7 @@ public class TextCell extends FrameLayout {
         imageView.setPadding(dp(2), dp(2), dp(2), dp(2));
         imageView.setTranslationX(dp(LocaleController.isRTL ? 0 : -3));
         imageView.setImageResource(resId);
-        Theme.applyThemeMonetColor(imageView, resourcesProvider);
+        Theme.applyThemeMonetColor(imageView, resourcesProvider, true);
 
         final boolean border = resourcesProvider != null ? resourcesProvider.isDark() : Theme.isCurrentThemeDark();
         SettingsActivity.SettingCell.Background drawable = new SettingsActivity.SettingCell.Background();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/TextCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/TextCell.java
@@ -626,7 +626,11 @@ public class TextCell extends FrameLayout {
         imageView.setPadding(dp(2), dp(2), dp(2), dp(2));
         imageView.setTranslationX(dp(LocaleController.isRTL ? 0 : -3));
         imageView.setImageResource(resId);
-        imageView.setColorFilter(new PorterDuffColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN));
+        imageView.setColorFilter(new PorterDuffColorFilter(
+                Theme.isCurrentThemeMonet(resourcesProvider)
+                        ? Theme.getColor(Theme.key_chats_actionIcon, resourcesProvider)
+                        : Color.WHITE,
+                PorterDuff.Mode.SRC_IN));
 
         final boolean border = resourcesProvider != null ? resourcesProvider.isDark() : Theme.isCurrentThemeDark();
         SettingsActivity.SettingCell.Background drawable = new SettingsActivity.SettingCell.Background();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/TextCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/TextCell.java
@@ -626,11 +626,7 @@ public class TextCell extends FrameLayout {
         imageView.setPadding(dp(2), dp(2), dp(2), dp(2));
         imageView.setTranslationX(dp(LocaleController.isRTL ? 0 : -3));
         imageView.setImageResource(resId);
-        imageView.setColorFilter(new PorterDuffColorFilter(
-                Theme.isCurrentThemeMonet(resourcesProvider)
-                        ? Theme.getColor(Theme.key_chats_actionIcon, resourcesProvider)
-                        : Color.WHITE,
-                PorterDuff.Mode.SRC_IN));
+        Theme.applyThemeMonetColor(imageView, resourcesProvider);
 
         final boolean border = resourcesProvider != null ? resourcesProvider.isDark() : Theme.isCurrentThemeDark();
         SettingsActivity.SettingCell.Background drawable = new SettingsActivity.SettingCell.Background();

--- a/TMessagesProj/src/main/java/org/telegram/ui/DataUsage2Activity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DataUsage2Activity.java
@@ -1056,11 +1056,7 @@ public class DataUsage2Activity extends BaseFragment {
                 drawable.setColor(imageColorTop, imageColorBottom);
                 drawable.setDrawBorder(border);
                 imageView.setBackground(drawable);
-                imageView.setColorFilter(new PorterDuffColorFilter(
-                        Theme.isCurrentThemeMonet(resourcesProvider)
-                                ? Theme.getColor(Theme.key_chats_actionIcon, resourcesProvider)
-                                : 0xFFFFFFFF,
-                        PorterDuff.Mode.SRC_IN));
+                Theme.applyThemeMonetColor(imageView, resourcesProvider);
                 imageView.setImageResource(imageResId);
             }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/DataUsage2Activity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DataUsage2Activity.java
@@ -1056,7 +1056,7 @@ public class DataUsage2Activity extends BaseFragment {
                 drawable.setColor(imageColorTop, imageColorBottom);
                 drawable.setDrawBorder(border);
                 imageView.setBackground(drawable);
-                Theme.applyThemeMonetColor(imageView, resourcesProvider);
+                Theme.applyThemeMonetColor(imageView, resourcesProvider, false);
                 imageView.setImageResource(imageResId);
             }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/DataUsage2Activity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DataUsage2Activity.java
@@ -1056,6 +1056,11 @@ public class DataUsage2Activity extends BaseFragment {
                 drawable.setColor(imageColorTop, imageColorBottom);
                 drawable.setDrawBorder(border);
                 imageView.setBackground(drawable);
+                imageView.setColorFilter(new PorterDuffColorFilter(
+                        Theme.isCurrentThemeMonet(resourcesProvider)
+                                ? Theme.getColor(Theme.key_chats_actionIcon, resourcesProvider)
+                                : 0xFFFFFFFF,
+                        PorterDuff.Mode.SRC_IN));
                 imageView.setImageResource(imageResId);
             }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/SettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/SettingsActivity.java
@@ -1221,7 +1221,7 @@ public class SettingsActivity extends BaseFragment implements NotificationCenter
             subtitleView.setTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteGrayText, resourcesProvider));
             valueView.setTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteBlueText, resourcesProvider));
             iconBackground.setDrawBorder(resourcesProvider != null ? resourcesProvider.isDark() : Theme.isCurrentThemeDark());
-            Theme.applyThemeMonetColor(iconView, resourcesProvider);
+            Theme.applyThemeMonetColor(iconView, resourcesProvider, false);
         }
 
         private boolean twoLines;

--- a/TMessagesProj/src/main/java/org/telegram/ui/SettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/SettingsActivity.java
@@ -1221,11 +1221,7 @@ public class SettingsActivity extends BaseFragment implements NotificationCenter
             subtitleView.setTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteGrayText, resourcesProvider));
             valueView.setTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteBlueText, resourcesProvider));
             iconBackground.setDrawBorder(resourcesProvider != null ? resourcesProvider.isDark() : Theme.isCurrentThemeDark());
-            iconView.setColorFilter(new PorterDuffColorFilter(
-                    Theme.isCurrentThemeMonet(resourcesProvider)
-                            ? Theme.getColor(Theme.key_chats_actionIcon, resourcesProvider)
-                            : Color.WHITE,
-                    PorterDuff.Mode.SRC_IN));
+            Theme.applyThemeMonetColor(iconView, resourcesProvider);
         }
 
         private boolean twoLines;

--- a/TMessagesProj/src/main/java/org/telegram/ui/SettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/SettingsActivity.java
@@ -1221,6 +1221,11 @@ public class SettingsActivity extends BaseFragment implements NotificationCenter
             subtitleView.setTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteGrayText, resourcesProvider));
             valueView.setTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteBlueText, resourcesProvider));
             iconBackground.setDrawBorder(resourcesProvider != null ? resourcesProvider.isDark() : Theme.isCurrentThemeDark());
+            iconView.setColorFilter(new PorterDuffColorFilter(
+                    Theme.isCurrentThemeMonet(resourcesProvider)
+                            ? Theme.getColor(Theme.key_chats_actionIcon, resourcesProvider)
+                            : Color.WHITE,
+                    PorterDuff.Mode.SRC_IN));
         }
 
         private boolean twoLines;
@@ -1269,13 +1274,20 @@ public class SettingsActivity extends BaseFragment implements NotificationCenter
             }
 
             public void setColor(int topColor, int bottomColor) {
+                setColor(topColor, bottomColor, Theme.isCurrentThemeMonet());
+            }
+
+            public void setColor(int topColor, int bottomColor, boolean useAccentColor) {
+                if (useAccentColor) {
+                    topColor = bottomColor = Theme.getColor(Theme.key_chats_actionBackground);
+                }
                 gradient = new LinearGradient(0, 0, 0, dp(28), new int[] { topColor, bottomColor }, new float[] { 0, 1 }, Shader.TileMode.CLAMP);
                 paint.setShader(gradient);
             }
 
             private boolean border;
             public void setDrawBorder(boolean drawBorder) {
-                this.border = drawBorder;
+                this.border = drawBorder && !Theme.isCurrentThemeMonet();
             }
 
             @Override

--- a/TMessagesProj/src/main/java/org/telegram/ui/community/cells/CommunityRequestsCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/community/cells/CommunityRequestsCell.java
@@ -3,6 +3,8 @@ package org.telegram.ui.community.cells;
 import static org.telegram.messenger.AndroidUtilities.dp;
 
 import android.content.Context;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
 import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -103,6 +105,11 @@ public class CommunityRequestsCell extends LinearLayout implements Theme.Colorab
         valueView.setBackground(mUnreadMode ? Theme.createRoundRectDrawable(dp(10.33f), Theme.getColor(Theme.key_chats_unreadCounter, resourcesProvider)) : null);
 
         iconBackground.setDrawBorder(resourcesProvider != null ? resourcesProvider.isDark() : Theme.isCurrentThemeDark());
+        iconView.setColorFilter(new PorterDuffColorFilter(
+                Theme.isCurrentThemeMonet(resourcesProvider)
+                        ? Theme.getColor(Theme.key_chats_actionIcon, resourcesProvider)
+                        : 0xFFFFFFFF,
+                PorterDuff.Mode.SRC_IN));
     }
 
     public void set(

--- a/TMessagesProj/src/main/java/org/telegram/ui/community/cells/CommunityRequestsCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/community/cells/CommunityRequestsCell.java
@@ -3,8 +3,6 @@ package org.telegram.ui.community.cells;
 import static org.telegram.messenger.AndroidUtilities.dp;
 
 import android.content.Context;
-import android.graphics.PorterDuff;
-import android.graphics.PorterDuffColorFilter;
 import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -105,11 +103,7 @@ public class CommunityRequestsCell extends LinearLayout implements Theme.Colorab
         valueView.setBackground(mUnreadMode ? Theme.createRoundRectDrawable(dp(10.33f), Theme.getColor(Theme.key_chats_unreadCounter, resourcesProvider)) : null);
 
         iconBackground.setDrawBorder(resourcesProvider != null ? resourcesProvider.isDark() : Theme.isCurrentThemeDark());
-        iconView.setColorFilter(new PorterDuffColorFilter(
-                Theme.isCurrentThemeMonet(resourcesProvider)
-                        ? Theme.getColor(Theme.key_chats_actionIcon, resourcesProvider)
-                        : 0xFFFFFFFF,
-                PorterDuff.Mode.SRC_IN));
+        Theme.applyThemeMonetColor(iconView, resourcesProvider);
     }
 
     public void set(

--- a/TMessagesProj/src/main/java/org/telegram/ui/community/cells/CommunityRequestsCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/community/cells/CommunityRequestsCell.java
@@ -103,7 +103,7 @@ public class CommunityRequestsCell extends LinearLayout implements Theme.Colorab
         valueView.setBackground(mUnreadMode ? Theme.createRoundRectDrawable(dp(10.33f), Theme.getColor(Theme.key_chats_unreadCounter, resourcesProvider)) : null);
 
         iconBackground.setDrawBorder(resourcesProvider != null ? resourcesProvider.isDark() : Theme.isCurrentThemeDark());
-        Theme.applyThemeMonetColor(iconView, resourcesProvider);
+        Theme.applyThemeMonetColor(iconView, resourcesProvider, false);
     }
 
     public void set(


### PR DESCRIPTION
adaptive icons in Monet theme, like in IdealGram or exteraGram

thanks to @IdealGram & @exteraGram

## Summary by Sourcery

Support Monet-aware styling for colorful settings, poll, data usage, and community icons.

New Features:
- Adapt colorful and action icons to use Monet theme accent colors.

Enhancements:
- Add theme-level Monet detection for current themes and resource providers.
- Adjust Monet icon backgrounds and borders for consistent adaptive styling.