### PR TITLE
chore: remove unused import [skip ci]

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ViewPagerFixed.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ViewPagerFixed.java
@@ -58,7 +58,6 @@ import org.telegram.ui.Stories.recorder.HintView2;
 
 import java.util.ArrayList;
 
-import tw.nekomimi.nekogram.NekoConfig;
 import xyz.nextalone.nagram.NaConfig;
 import xyz.nextalone.nagram.TabStyle;
 


### PR DESCRIPTION
removed an unused import that was added by accident in this commit:
https://github.com/waifucon/Nagram/commit/69c0851c59305aec60312b2d067c68fdc69ba668

## Summary by Sourcery

Enhancements:
- Remove the unused NekoConfig import from ViewPagerFixed.