### PR TITLE
test: repair two stale unit tests against current APIs

### DIFF
--- a/TMessagesProj/src/test/java/org/telegram/messenger/UserConfigAccountLimitTest.java
+++ b/TMessagesProj/src/test/java/org/telegram/messenger/UserConfigAccountLimitTest.java
@@ -1,10 +1,7 @@
 package org.telegram.messenger;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
-import android.app.Activity;
 import android.content.Context;
 import android.util.SparseArray;
 
@@ -39,32 +36,28 @@ public class UserConfigAccountLimitTest {
         resetState();
     }
 
+    // NOTE: requestAccountSlot() falls back to ExtendedHelper.getInstance().hasExtended()
+    // once the account count reaches getMaxAccountCount(). That call chain reaches
+    // MessagesController -> ConnectionsManager.native_isTestBackend(), a JNI method with
+    // no Robolectric shadow, so it throws UnsatisfiedLinkError under a plain JVM unit test.
+    // These tests therefore only cover slot assignment strictly below the cap; the
+    // beyond-cap / extended-unlock branch needs an instrumented (on-device) test instead.
+
     @Test
-    public void defaultLimitUnlocksExtendedSlotsOnFifthAttempt() {
-        activateAccounts(UserConfig.MAX_ACCOUNT_DEFAULT_COUNT, false);
+    public void slotIsAssignedBelowDefaultLimit() {
+        activateAccounts(UserConfig.MAX_ACCOUNT_DEFAULT_COUNT - 1, false);
 
         assertEquals(128, UserConfig.MAX_ACCOUNT_COUNT);
         assertEquals(8, UserConfig.getMaxAccountCount());
-        for (int i = 0; i < 4; i++) {
-            assertEquals(-1, UserConfig.requestAccountSlot());
-            assertFalse(SharedConfig.isExtendedAccountLimitUnlocked());
-        }
-
-        assertEquals(8, UserConfig.requestAccountSlot());
-        assertTrue(SharedConfig.isExtendedAccountLimitUnlocked());
-        assertEquals(8, UserConfig.requestAccountSlot());
+        assertEquals(UserConfig.MAX_ACCOUNT_DEFAULT_COUNT - 1, UserConfig.requestAccountSlot());
     }
 
     @Test
-    public void premiumLimitRemainsTenBeforeHiddenUnlock() {
-        activateAccounts(UserConfig.MAX_ACCOUNT_PREMIUM_COUNT, true);
+    public void slotIsAssignedBelowPremiumLimit() {
+        activateAccounts(UserConfig.MAX_ACCOUNT_PREMIUM_COUNT - 1, true);
 
         assertEquals(10, UserConfig.getMaxAccountCount());
-        for (int i = 0; i < 4; i++) {
-            assertEquals(-1, UserConfig.requestAccountSlot());
-        }
-
-        assertEquals(10, UserConfig.requestAccountSlot());
+        assertEquals(UserConfig.MAX_ACCOUNT_PREMIUM_COUNT - 1, UserConfig.requestAccountSlot());
     }
 
     private void activateAccounts(int count, boolean premium) {
@@ -81,22 +74,11 @@ public class UserConfigAccountLimitTest {
         SharedConfig.activeAccounts = new CopyOnWriteArraySet<>();
         clearSparseArray(UserConfig.class, "Instance");
         clearSparseArray(AccountInstance.class, "Instance");
-        setStaticField(UserConfig.class, "extendedAccountUnlockAttempts", 0);
-        setStaticField(SharedConfig.class, "extendedAccountLimitUnlocked", false);
-        context.getSharedPreferences("mainconfig", Activity.MODE_PRIVATE).edit()
-                .remove("extended_account_limit_unlocked")
-                .commit();
     }
 
     private static void clearSparseArray(Class<?> owner, String fieldName) throws Exception {
         Field field = owner.getDeclaredField(fieldName);
         field.setAccessible(true);
         ((SparseArray<?>) field.get(null)).clear();
-    }
-
-    private static void setStaticField(Class<?> owner, String fieldName, Object value) throws Exception {
-        Field field = owner.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        field.set(null, value);
     }
 }

--- a/TMessagesProj/src/test/java/org/telegram/ui/DialogsRecentForwardHelperTest.java
+++ b/TMessagesProj/src/test/java/org/telegram/ui/DialogsRecentForwardHelperTest.java
@@ -3,9 +3,11 @@ package org.telegram.ui;
 import org.junit.Test;
 import org.telegram.tgnet.TLRPC;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -23,7 +25,7 @@ public class DialogsRecentForwardHelperTest {
 
         assertEquals(
                 Arrays.asList(11L, -22L, 33L),
-                DialogsRecentForwardHelper.dialogIds(
+                idsInOrder(
                         DialogsRecentForwardHelper.buildRecentDialogs(
                                 Arrays.asList(11L, -22L, 0L, 11L, 33L),
                                 Arrays.asList(existingUser, existingChat),
@@ -69,5 +71,13 @@ public class DialogsRecentForwardHelperTest {
         assertTrue(DialogsActivity.isForwardPickerDialogsType(DialogsActivity.DIALOGS_TYPE_FORWARD));
         assertTrue(DialogsActivity.isForwardPickerDialogsType(DialogsActivity.DIALOGS_TYPE_FORWARD_RECENT));
         assertFalse(DialogsActivity.isForwardPickerDialogsType(DialogsActivity.DIALOGS_TYPE_DEFAULT));
+    }
+
+    private static List<Long> idsInOrder(List<TLRPC.Dialog> dialogs) {
+        List<Long> ids = new ArrayList<>();
+        for (TLRPC.Dialog dialog : dialogs) {
+            ids.add(dialog.id);
+        }
+        return ids;
     }
 }


### PR DESCRIPTION
Both tests fail to compile, which blocks the whole `testDebugUnitTest` task: Gradle compiles all of `src/test` before running any filtered subset, so no unit test in the module can run on `main` today.

They drifted because no CI workflow runs `testDebugUnitTest` — `pr.yml`, `debug.yml`, `release.yml` and `.gitlab-ci.yml` all only run `assembleRelease` — so later refactors broke them silently.

### `DialogsRecentForwardHelperTest`

Calls `DialogsRecentForwardHelper.dialogIds()`, which the helper has never had. The real API is `dialogIdSet()`, returning an unordered `HashSet`, so it cannot assert recency order. Replaced with a local helper that preserves list order.

### `UserConfigAccountLimitTest`

Asserts a "5th attempt unlocks extended slots" mechanism through `SharedConfig.isExtendedAccountLimitUnlocked()`, removed when the account-limit logic moved to `ExtendedHelper.hasExtended()` (token-based rather than attempt-counted).

Calling `hasExtended()` from a JVM test is not possible: it initialises `NaConfig` → `LocaleController` → `MessagesController` → `ConnectionsManager.native_isTestBackend()`, a JNI method with no Robolectric shadow, raising `UnsatisfiedLinkError`. Both tests are therefore narrowed to slot assignment strictly below the cap, with a comment recording why the beyond-cap branch needs an instrumented test instead.

### Result

`./gradlew TMessagesProj:testDebugUnitTest` now compiles and runs: 16 tests, 14 passing.

The 2 remaining failures (`OpenCCTest`, `DnsFactoryTest`) are pre-existing and left untouched — both load a native library extracted from app assets, which a plain JVM run cannot provide. Happy to address them in a follow-up if you would like them `@Ignore`d or reworked.

## Summary by Sourcery

Restore JVM unit-test compatibility by updating stale dialog-ordering and account-limit tests to reflect current APIs and supported execution constraints.

Bug Fixes:
- Repair stale unit tests so they compile against the current dialog helper and account-limit APIs.
- Update account-limit coverage to validate slot assignment below the supported default and premium caps without relying on removed unlock behavior.

Enhancements:
- Preserve recent-dialog ordering in test assertions while filtering invalid and duplicate IDs.
- Document that testing extended account-limit behavior requires an instrumented environment because it depends on native code.

Tests:
- Align unit tests with current APIs and remove obsolete state-reset logic for the retired attempt-based account unlock mechanism.