### PR TITLE
style: update default config value

### DIFF
--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -586,7 +586,7 @@ object NaConfig {
         addConfig(
             "DisableFlagSecure",
             ConfigItem.configTypeBool,
-            true
+            false
         )
     val centerActionBarTitle =
         addConfig(


### PR DESCRIPTION
hi the default value of DisableFlagSecure is false.

It's been wrongly registered in NaConfig.kt, when turning on disable flag secure, it would disappear from the nagram backup file, this pr should fix the issue.

## Summary by Sourcery

Bug Fixes:
- Correct the default value of DisableFlagSecure to false so the setting is preserved correctly in Nagram backup files.