### PR TITLE
chore: remove tgx in custom api

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
@@ -10587,16 +10587,8 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
             }
             return Unit.INSTANCE;
         });
-        builder.addRadioItem(LocaleController.getString(R.string.CustomApiTGX), NekoXConfig.customApi == 2, (cell) -> {
+        builder.addRadioItem(LocaleController.getString(R.string.CustomApiInput), NekoXConfig.customApi == 2, (cell) -> {
             targetApi.set(2);
-            builder.doRadioCheck(cell);
-            for (EditText input : inputs) {
-                input.setVisibility(View.GONE);
-            }
-            return Unit.INSTANCE;
-        });
-        builder.addRadioItem(LocaleController.getString(R.string.CustomApiInput), NekoXConfig.customApi > 2, (cell) -> {
-            targetApi.set(3);
             builder.doRadioCheck(cell);
             for (EditText input : inputs) {
                 input.setVisibility(View.VISIBLE);
@@ -10655,7 +10647,7 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
         builder.addCancelButton();
         builder.addButton(LocaleController.getString(R.string.Set), (it) -> {
             int target = targetApi.get();
-            if (target > 2) {
+            if (target == 2) {
                 if (NekoXConfig.customAppId == 0) {
                     inputs[0].requestFocus();
                     AndroidUtilities.showKeyboard(inputs[0]);

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoXConfig.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoXConfig.java
@@ -89,8 +89,6 @@ public class NekoXConfig {
                 return BuildConfig.APP_ID;
             case 1:
                 return BuildVars.OFFICAL_APP_ID;
-            case 2:
-                return BuildVars.TGX_APP_ID;
             default:
                 return customAppId;
         }
@@ -103,8 +101,6 @@ public class NekoXConfig {
                 return BuildConfig.APP_HASH;
             case 1:
                 return BuildVars.OFFICAL_APP_HASH;
-            case 2:
-                return BuildVars.TGX_APP_HASH;
             default:
                 return customAppHash;
         }


### PR DESCRIPTION
removed tgx, it doesn't work anymore for sign-in.

I've still kept it in BuildVars.java it might be useful at a time.

Verification:
It compiles successfully

## Summary by Sourcery

Remove TGX from the custom API sign-in configuration and use manual API credentials for the remaining custom option.

Bug Fixes:
- Remove the nonfunctional TGX custom API sign-in option.

Enhancements:
- Simplify custom API selection to support user-provided credentials only while retaining existing build-variable definitions.