### PR TITLE
feat: add option for Bot API style id display

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
@@ -3836,7 +3836,7 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
                 avatarContainer2.setPivotX(avatarContainer2.getMeasuredWidth() / 2f);
                 AndroidUtilities.updateViewVisibilityAnimated(avatarContainer2, !expanded, 0.95f, true);
 
-                if (Math.min(1f, extraHeight / AndroidUtilities.dp(88f)) > 0.85 && !searchMode && NekoConfig.showIdAndDc.Bool())
+                if (Math.min(1f, extraHeight / AndroidUtilities.dp(88f)) > 0.85 && !searchMode && NaConfig.INSTANCE.getIdDcType().Int() != 0)
                     idTextView.setVisibility(expanded ? INVISIBLE : VISIBLE);
 
                 callItem.setVisibility(expanded || !callItemVisible ? GONE : INVISIBLE);
@@ -9235,7 +9235,7 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
                 mediaCounterTextView.setTranslationY(onlineY);
                 updateCollectibleHint();
 
-                if (diff > 0.85 && !searchMode && NekoConfig.showIdAndDc.Bool()) {
+                if (diff > 0.85 && !searchMode && NaConfig.INSTANCE.getIdDcType().Int() != 0) {
                     idTextView.setVisibility(View.VISIBLE);
                 } else {
                     idTextView.setVisibility(View.GONE);
@@ -12136,12 +12136,12 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
             }
 
             dc = user.photo != null && user.photo.dc_id != 0 ? user.photo.dc_id : (UserObject.isUserSelf(user) && getMessagesController().thisDc > 0) ? getMessagesController().thisDc : 0;
+            id = getId(true);
             if (dc != 0) {
-                idTextView.setText("ID: " + userId + ", DC: " + dc);
+                idTextView.setText("ID: " + id + ", DC: " + dc);
             } else {
-                idTextView.setText("ID: " + userId);
+                idTextView.setText("ID: " + id);
             }
-            id = userId;
             avatarImage.getImageReceiver().setVisible(!PhotoViewer.isShowingImage(photoBig) && (getLastStoryViewer() == null || getLastStoryViewer().transitionViewHolder.view != avatarImage), storyView != null);
         } else if (chatId != 0) {
             TLRPC.Chat chat = getMessagesController().getChat(chatId);
@@ -12456,18 +12456,21 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
             if (dc == 0 && chat.photo != null && chat.photo.dc_id != 0) {
                 dc = chat.photo.dc_id;
             }
+            id = getId(true);
             if (dc != 0) {
-                idTextView.setText("ID: " + chatId + ", DC: " + dc);
+                idTextView.setText("ID: " + id + ", DC: " + dc);
             } else {
-                idTextView.setText("ID: " + chatId);
+                idTextView.setText("ID: " + id);
             }
         }
+        long idForLink = getId(false);
         if (id != 0) {
             long finalId = id;
+            long finalIdForLink = idForLink;
             int finalDc = dc;
             idTextView.setOnClickListener(v -> {
                 ItemOptions o = ItemOptions.makeOptions(this, v);
-                if (finalId == userId) {
+                if (userId != 0) {
                     ItemOptionsPatch.addTitle(o, finalId + "", ProfileDateHelper.getUserTime(finalId));
                 } else {
                     ItemOptionsPatch.addTitle(o, finalId + "", null);
@@ -12475,19 +12478,19 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
                 o.add(R.drawable.msg_copy, LocaleController.getString(R.string.Copy), () -> {
                     AlertUtil.copyAndAlert(finalId + "");
                 });
-                if (finalId == userId) {
+                if (userId != 0) {
                     o.add(R.drawable.profile_link, LocaleController.getString(R.string.CopyLink), () -> {
-                        AlertUtil.copyLinkAndAlert("tg://user?id=" + finalId);
+                        AlertUtil.copyLinkAndAlert("tg://user?id=" + finalIdForLink);
                     });
                     o.add(R.drawable.profile_link, LocaleController.getString(R.string.CopyLink) + " (Android)", () -> {
-                        AlertUtil.copyLinkAndAlert("tg://openmessage?user_id=" + finalId);
+                        AlertUtil.copyLinkAndAlert("tg://openmessage?user_id=" + finalIdForLink);
                     });
                     o.add(R.drawable.profile_link, LocaleController.getString(R.string.CopyLink) + " (IOS)", () -> {
-                        AlertUtil.copyLinkAndAlert("https://t.me/@id" + finalId);
+                        AlertUtil.copyLinkAndAlert("https://t.me/@id" + finalIdForLink);
                     });
                 } else {
                     o.add(R.drawable.profile_link, LocaleController.getString(R.string.CopyLink) + " (Android)", () -> {
-                        AlertUtil.copyLinkAndAlert("tg://openmessage?chat_id=" + finalId);
+                        AlertUtil.copyLinkAndAlert("tg://openmessage?chat_id=" + finalIdForLink);
                     });
                 }
                 if (finalDc != 0) {
@@ -12504,6 +12507,21 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
         }
 
         needLayout(true);
+    }
+
+    private long getId(boolean styled) {
+        long id = userId != 0 ? userId : chatId != 0 ? chatId : 0;
+        if (styled && chatId != 0 && NaConfig.INSTANCE.getIdDcType().Int() == NekoConfig.ID_TYPE_BOT_API) {
+            TLRPC.Chat chat = getMessagesController().getChat(chatId);
+            if (chat != null) {
+                if (ChatObject.isChannel(chat)) {
+                    id = -1000000000000L - chat.id;
+                } else {
+                    id = -chat.id;
+                }
+            }
+        }
+        return id;
     }
 
     private CharSequence appendCommunityHiddenRow(CharSequence text) {
@@ -13288,7 +13306,7 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
         nameTextView[1].setVisibility(View.VISIBLE);
         onlineTextView[1].setVisibility(View.VISIBLE);
         onlineTextView[3].setVisibility(View.VISIBLE);
-        if (Math.min(1f, extraHeight / AndroidUtilities.dp(88f)) > 0.85 && !searchMode && NekoConfig.showIdAndDc.Bool())
+        if (Math.min(1f, extraHeight / AndroidUtilities.dp(88f)) > 0.85 && !searchMode && NaConfig.INSTANCE.getIdDcType().Int() != 0)
             idTextView.setVisibility(View.VISIBLE);
 
         actionBar.onSearchFieldVisibilityChanged(searchTransitionProgress > 0.5f);

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoConfig.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoConfig.java
@@ -36,6 +36,10 @@ public class NekoConfig {
     public static boolean showGhostToggleInDrawer;
     public static final String channelAliasPrefix = "channelAliasPrefix_";
 
+    public static final int ID_TYPE_HIDDEN = 0;
+    public static final int ID_TYPE_API = 1;
+    public static final int ID_TYPE_BOT_API = 2;
+
     private static boolean configLoaded = false;
     private static final ArrayList<ConfigItem> configs = new ArrayList<>();
     public static final ArrayList<DatacenterInfo> datacenterInfos = new ArrayList<>(5);

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
@@ -289,7 +289,11 @@ private final AbstractConfigCell defaultHlsVideoQualityRow = cellGroup.appendCel
     private final AbstractConfigCell customTitleUserNameRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getCustomTitleUserName()));
     private final AbstractConfigCell useSystemUnlockRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getUseSystemUnlock()));
     private final AbstractConfigCell disableUndoRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.disableUndo));
-    private final AbstractConfigCell showIdAndDcRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.showIdAndDc));
+    private final AbstractConfigCell showIdAndDcRow = cellGroup.appendCell(new ConfigCellSelectBox("ShowIdAndDc", NaConfig.INSTANCE.getIdDcType(), new String[]{
+            LocaleController.getString(R.string.Disable),
+            "Telegram API",
+            "Bot API"
+    }, null));
     private final AbstractConfigCell inappCameraRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.inappCamera));
     private final AbstractConfigCell autoPauseVideoRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.autoPauseVideo, LocaleController.getString("AutoPauseVideoAbout")));
     private final AbstractConfigCell disableNumberRoundingRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.disableNumberRounding, "4.8K -> 4777"));

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -1367,6 +1367,12 @@ object NaConfig {
             ConfigItem.configTypeBool,
             false
         )
+    val idDcType =
+        addConfig(
+            "IdDcType",
+            ConfigItem.configTypeInt,
+            1
+        )
 
     private fun addConfig(
         k: String,
@@ -1507,6 +1513,9 @@ object NaConfig {
                     o as ConfigItemKeyLinked
                     o.changedFromKeyLinked(o.keyLinked.Int())
                 }
+            }
+            if (!preferences.getBoolean("ShowIdAndDc", true)) {
+                idDcType.setConfigInt(0)
             }
             configLoaded =
                 true


### PR DESCRIPTION
thanks to @NagramX

https://github.com/risin42/NagramX/commit/e09b06c678a56eab032a0099f0ed936b79f4de44
https://github.com/risin42/NagramX/commit/ab859b0c778656cfbd92be75251bb6fa7bae7696

## Summary by Sourcery

Add configurable Telegram API and Bot API profile ID display modes.

New Features:
- Add a General Settings selector to disable profile IDs or display them using Telegram API or Bot API formats.

Bug Fixes:
- Preserve the underlying numeric ID for profile links and actions while allowing chat IDs to use Bot API formatting for display.

Enhancements:
- Update profile ID and datacenter visibility and formatting to use the new ID display preference.

Chores:
- Retain compatibility with the previous ShowIdAndDc preference when loading configuration.