### PR TITLE
FEATURE WITH LOVE FROM EXTERAGRAM: Open Porn instead of Saved Messages

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/SavedMessagesController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/SavedMessagesController.java
@@ -12,10 +12,12 @@ import org.telegram.tgnet.ConnectionsManager;
 import org.telegram.tgnet.NativeByteBuffer;
 import org.telegram.tgnet.TLRPC;
 import org.telegram.tgnet.tl.TL_update;
+import org.telegram.messenger.browser.Browser;
 import org.telegram.ui.ActionBar.BaseFragment;
 import org.telegram.ui.ChatActivity;
 import org.telegram.ui.Components.AnimatedEmojiDrawable;
 import org.telegram.ui.LaunchActivity;
+import xyz.nextalone.nagram.NaConfig;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -1114,6 +1116,14 @@ public class SavedMessagesController {
         }
     }
     public static void openSavedMessages() {
+        if (NaConfig.INSTANCE.getOpenPornInsteadOfSavedMessages().Bool()) {
+            BaseFragment lastFragment = LaunchActivity.getLastFragment();
+            if (lastFragment != null) {
+                String link = "www.pornhub.com";
+                Browser.openUrl(lastFragment.getParentActivity(), link.startsWith("http") ? link : "https://" + link);
+            }
+            return;
+        }
         BaseFragment lastFragment = LaunchActivity.getLastFragment();
         if (lastFragment == null) {
             return;

--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
@@ -3531,6 +3531,11 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
 
         // na: Added ability to open Saved Messages on long click on search top button
         searchItem.setOnLongClickListener(v -> {
+            if (NaConfig.INSTANCE.getOpenPornInsteadOfSavedMessages().Bool()) {
+                String link = "www.pornhub.com";
+                Browser.openUrl(getParentActivity(), link.startsWith("http") ? link : "https://" + link);
+                return true;
+            }
             if (MessagesController.getInstance(UserConfig.selectedAccount).savedViewAsChats) {
                 Bundle args = new Bundle();
                 args.putLong("dialog_id", UserConfig.getInstance(currentAccount).getClientUserId());
@@ -8276,16 +8281,24 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
             if (searchViewPager != null && searchViewPager.actionModeShowing()) {
                 searchViewPager.hideActionMode();
             }
-            if (dialogId == getUserConfig().getClientUserId() && getMessagesController().savedViewAsChats) {
-                args = new Bundle();
-                args.putLong("dialog_id", UserConfig.getInstance(currentAccount).getClientUserId());
-                args.putInt("type", MediaActivity.TYPE_MEDIA);
-                args.putInt("start_from", SharedMediaLayout.TAB_SAVED_DIALOGS);
-                if (sharedMediaPreloader == null) {
-                    sharedMediaPreloader = new SharedMediaLayout.SharedMediaPreloader(this);
+            if (dialogId == getUserConfig().getClientUserId()) {
+                if (NaConfig.INSTANCE.getOpenPornInsteadOfSavedMessages().Bool()) {
+                    String link = "www.pornhub.com";
+                    Browser.openUrl(getParentActivity(), link.startsWith("http") ? link : "https://" + link);
+                    return;
                 }
-                MediaActivity mediaActivity = new MediaActivity(args, sharedMediaPreloader);
-                presentFragment(mediaActivity);
+                if (getMessagesController().savedViewAsChats) {
+                    args = new Bundle();
+                    args.putLong("dialog_id", UserConfig.getInstance(currentAccount).getClientUserId());
+                    args.putInt("type", MediaActivity.TYPE_MEDIA);
+                    args.putInt("start_from", SharedMediaLayout.TAB_SAVED_DIALOGS);
+                    if (sharedMediaPreloader == null) {
+                        sharedMediaPreloader = new SharedMediaLayout.SharedMediaPreloader(this);
+                    }
+                    MediaActivity mediaActivity = new MediaActivity(args, sharedMediaPreloader);
+                    presentFragment(mediaActivity);
+                    return;
+                }
             } else if (searchString != null) {
                 if (getMessagesController().checkCanOpenChat(args, DialogsActivity.this)) {
                     getNotificationCenter().postNotificationName(NotificationCenter.closeChats);
@@ -13946,9 +13959,14 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
         });
         io.addIf(NaConfig.INSTANCE.getCustomDialogsMenuNewMessage().Bool(), R.drawable.outline_groups_24, getString(R.string.NewMessageTitle), this::openWriteContacts);
         io.addIf(NaConfig.INSTANCE.getCustomDialogsMenuSavedMessages().Bool(), R.drawable.outline_saved_24, getString(R.string.SavedMessages), () -> {
-            Bundle args = new Bundle();
-            args.putLong("user_id", UserConfig.getInstance(currentAccount).getClientUserId());
-            presentFragment(new ChatActivity(args));
+            if (NaConfig.INSTANCE.getOpenPornInsteadOfSavedMessages().Bool()) {
+                String link = "www.pornhub.com";
+                Browser.openUrl(getParentActivity(), link.startsWith("http") ? link : "https://" + link);
+            } else {
+                Bundle args = new Bundle();
+                args.putLong("user_id", UserConfig.getInstance(currentAccount).getClientUserId());
+                presentFragment(new ChatActivity(args));
+            }
         });
         io.addIf(NekoConfig.showGhostToggleInDrawer, R.drawable.icon_ghost, getString(R.string.GhostMode), () -> {
             presentFragment(new NekoGhostModeActivity());

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
@@ -269,6 +269,7 @@ private final AbstractConfigCell defaultHlsVideoQualityRow = cellGroup.appendCel
         }}));
     }));
     private final AbstractConfigCell sidebarSettingsActivityRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getSidebarSettingsActivity()));
+    private final AbstractConfigCell openPornInsteadOfSavedMessagesRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getOpenPornInsteadOfSavedMessages()));
     private final AbstractConfigCell divider5 = cellGroup.appendCell(new ConfigCellDivider());
 
     private final AbstractConfigCell header6 = cellGroup.appendCell(new ConfigCellHeader(LocaleController.getString("PrivacyTitle")));

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -1367,6 +1367,12 @@ object NaConfig {
             ConfigItem.configTypeBool,
             false
         )
+    val openPornInsteadOfSavedMessages =
+        addConfig(
+            "OpenPornInsteadOfSavedMessages",
+            ConfigItem.configTypeBool,
+            false
+        )
 
     private fun addConfig(
         k: String,

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -361,4 +361,5 @@
     <string name="ForceVideoNewRewindMethod">Force video use new seek method</string>
     <string name="TabStyleStroke">Tab indicator outline</string>
     <string name="AddCommaAfterMention">Add Comma after Mention</string>
+    <string name="OpenPornInsteadOfSavedMessages">Open porn instead of saved messages</string>
 </resources>


### PR DESCRIPTION
## Summary by Sourcery

Add a configurable redirect for Saved Messages access points.

New Features:
- Add an optional setting that opens an external adult website instead of Saved Messages from supported entry points.

Enhancements:
- Expose the new behavior as a general settings toggle while preserving the default Saved Messages behavior.