### PR TITLE
feat: add live message previews to chat settings

### DIFF
--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/config/cell/ConfigCellCustom.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/config/cell/ConfigCellCustom.java
@@ -9,6 +9,7 @@ public class ConfigCellCustom extends AbstractConfigCell {
     public static final int CUSTOM_ITEM_EmojiSet = 996;
     public static final int CUSTOM_ITEM_LiquidGlassAngle = 995;
     public static final int CUSTOM_ITEM_LiquidGlassIntensity = 994;
+    public static final int CUSTOM_ITEM_MessagesPreview = 993;
 
     public final int type;
     public boolean enabled;

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/config/cell/ConfigCellTextInput.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/config/cell/ConfigCellTextInput.java
@@ -27,6 +27,7 @@ public class ConfigCellTextInput extends AbstractConfigCell {
     public TextSettingsCell cell;
     private final Runnable onClickCustom;
     private final Function<String, String> inputChecker;
+    private final boolean rebuildOnChange;
 
     public ConfigCellTextInput(String customTitle, ConfigItem bind, String hint, Runnable customOnClick) {
         this(customTitle, bind, hint, customOnClick, null);
@@ -34,6 +35,10 @@ public class ConfigCellTextInput extends AbstractConfigCell {
 
     // default: customTitle=null customOnClick=null
     public ConfigCellTextInput(String customTitle, ConfigItem bind, String hint, Runnable customOnClick, Function<String, String> inputChecker) {
+        this(customTitle, bind, hint, customOnClick, inputChecker, true);
+    }
+
+    public ConfigCellTextInput(String customTitle, ConfigItem bind, String hint, Runnable customOnClick, Function<String, String> inputChecker, boolean rebuildOnChange) {
         this.bindConfig = bind;
         if (hint == null) {
             this.hint = "";
@@ -47,6 +52,7 @@ public class ConfigCellTextInput extends AbstractConfigCell {
         }
         this.onClickCustom = customOnClick;
         this.inputChecker = inputChecker;
+        this.rebuildOnChange = rebuildOnChange;
     }
 
     public int getType() {
@@ -119,7 +125,9 @@ public class ConfigCellTextInput extends AbstractConfigCell {
             //refresh
             cellGroup.listAdapter.notifyItemChanged(cellGroup.rows.indexOf(this));
             builder.getDismissRunnable().run();
-            cellGroup.thisFragment.getParentLayout().rebuildAllFragmentViews(false, false);
+            if (rebuildOnChange) {
+                cellGroup.thisFragment.getParentLayout().rebuildAllFragmentViews(false, false);
+            }
 
             cellGroup.runCallback(bindConfig.getKey(), newV);
         });
@@ -127,4 +135,3 @@ public class ConfigCellTextInput extends AbstractConfigCell {
         cellGroup.thisFragment.showDialog(builder.create());
     }
 }
-

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/MessagesPreviewCell.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/MessagesPreviewCell.java
@@ -1,6 +1,3 @@
-/*
- * Adapted from the exteraGram message preview used by Materialgram.
- */
 package tw.nekomimi.nekogram.settings;
 
 import android.annotation.SuppressLint;
@@ -18,8 +15,9 @@ import android.widget.LinearLayout;
 import org.telegram.messenger.AndroidUtilities;
 import org.telegram.messenger.LocaleController;
 import org.telegram.messenger.MessageObject;
+import org.telegram.messenger.MessagesController;
 import org.telegram.messenger.R;
-import org.telegram.messenger.UserConfig;
+import org.telegram.tgnet.TLObject;
 import org.telegram.tgnet.TLRPC;
 import org.telegram.ui.ActionBar.INavigationLayout;
 import org.telegram.ui.ActionBar.Theme;
@@ -30,6 +28,7 @@ import org.telegram.ui.Components.MotionBackgroundDrawable;
 
 import tw.nekomimi.nekogram.NekoConfig;
 import tw.nekomimi.nekogram.helpers.TimeStringHelper;
+import tw.nekomimi.nekogram.utils.UpdateUtil;
 import xyz.nextalone.nagram.NaConfig;
 
 @SuppressLint("ViewConstructor")
@@ -59,7 +58,7 @@ public class MessagesPreviewCell extends LinearLayout {
         setPadding(0, AndroidUtilities.dp(11), 0, AndroidUtilities.dp(11));
 
         int date = (int) (System.currentTimeMillis() / 1000) - 3600;
-        TLRPC.TL_message text = createMessage(account, 42, date);
+        TLRPC.TL_message text = createMessage(42, date);
         String markedText = LocaleController.getString(R.string.MessagePreviewText);
         int spoilerStart = markedText.indexOf("||");
         int spoilerEnd = spoilerStart < 0 ? -1 : markedText.indexOf("||", spoilerStart + 2);
@@ -81,11 +80,11 @@ public class MessagesPreviewCell extends LinearLayout {
         text.forwards = 12;
         text.fwd_from = new TLRPC.TL_messageFwdHeader();
         text.fwd_from.flags = 32;
-        text.fwd_from.from_name = "Nagram";
+        text.fwd_from.from_name = "monk 🥺";
         text.fwd_from.date = date - 86400;
         messages[0] = new MessageObject(account, text, true, false);
 
-        TLRPC.TL_message pollMessage = createMessage(account, 43, date + 120);
+        TLRPC.TL_message pollMessage = createMessage(43, date + 120);
         pollMessage.flags |= TLRPC.MESSAGE_FLAG_HAS_MEDIA;
         TLRPC.TL_messageMediaPoll media = new TLRPC.TL_messageMediaPoll();
         media.poll = new TLRPC.TL_poll();
@@ -93,7 +92,7 @@ public class MessagesPreviewCell extends LinearLayout {
         media.poll.question.text = LocaleController.getString(R.string.MessagePreviewPollQuestion);
         media.results = new TLRPC.TL_pollResults();
         media.results.flags = 2 | 4;
-        media.results.total_voters = 10;
+        media.results.total_voters = 16;
         int[] answers = {R.string.MessagePreviewPollAnswerTerrible, R.string.MessagePreviewPollAnswerWorse};
         for (int i = 0; i < answers.length; i++) {
             TLRPC.TL_pollAnswer answer = new TLRPC.TL_pollAnswer();
@@ -103,7 +102,7 @@ public class MessagesPreviewCell extends LinearLayout {
             media.poll.answers.add(answer);
             TLRPC.TL_pollAnswerVoters voters = new TLRPC.TL_pollAnswerVoters();
             voters.option = answer.option;
-            voters.voters = i == 0 ? 7 : 3;
+            voters.voters = i == 0 ? 11 : 5;
             media.results.results.add(voters);
         }
         pollMessage.media = media;
@@ -112,6 +111,7 @@ public class MessagesPreviewCell extends LinearLayout {
         TimeStringHelper.getForwardsDrawable();
         for (int i = 0; i < cells.length; i++) {
             messages[i].customName = "Nagram";
+            messages[i].forceAvatar = true;
             cells[i] = new ChatMessageCell(context, account);
             cells[i].setDelegate(new ChatMessageCell.ChatMessageCellDelegate() {
                 @Override
@@ -124,16 +124,39 @@ public class MessagesPreviewCell extends LinearLayout {
             addView(cells[i], LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT));
         }
         refreshMessages();
+        loadPreviewChannel(account);
     }
 
-    private static TLRPC.TL_message createMessage(int account, int id, int date) {
+    private void loadPreviewChannel(int account) {
+        MessagesController controller = MessagesController.getInstance(account);
+        TLObject cachedChannel = controller.getUserOrChat(UpdateUtil.channelUsername);
+        if (cachedChannel instanceof TLRPC.Chat) {
+            setPreviewChannel((TLRPC.Chat) cachedChannel);
+        }
+        controller.getUserNameResolver().resolve(UpdateUtil.channelUsername, peerId -> {
+            if (peerId != null && peerId < 0) {
+                TLRPC.Chat channel = controller.getChat(-peerId);
+                if (channel != null) {
+                    setPreviewChannel(channel);
+                }
+            }
+        });
+    }
+
+    private void setPreviewChannel(TLRPC.Chat channel) {
+        for (MessageObject message : messages) {
+            message.messageOwner.from_id.channel_id = channel.id;
+        }
+        refreshMessages();
+    }
+
+    private static TLRPC.TL_message createMessage(int id, int date) {
         TLRPC.TL_message message = new TLRPC.TL_message();
         message.id = id;
         message.date = date;
         message.dialog_id = 1;
         message.flags = TLRPC.MESSAGE_FLAG_HAS_FROM_ID;
-        message.from_id = new TLRPC.TL_peerUser();
-        message.from_id.user_id = UserConfig.getInstance(account).getClientUserId();
+        message.from_id = new TLRPC.TL_peerChannel();
         message.peer_id = new TLRPC.TL_peerUser();
         message.media = new TLRPC.TL_messageMediaEmpty();
         message.message = "";

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/MessagesPreviewCell.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/MessagesPreviewCell.java
@@ -1,0 +1,281 @@
+/*
+ * Adapted from the exteraGram message preview used by Materialgram.
+ */
+package tw.nekomimi.nekogram.settings;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.graphics.Canvas;
+import android.graphics.Shader;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
+import android.view.MotionEvent;
+import android.widget.LinearLayout;
+
+import org.telegram.messenger.AndroidUtilities;
+import org.telegram.messenger.LocaleController;
+import org.telegram.messenger.MessageObject;
+import org.telegram.messenger.R;
+import org.telegram.messenger.UserConfig;
+import org.telegram.tgnet.TLRPC;
+import org.telegram.ui.ActionBar.INavigationLayout;
+import org.telegram.ui.ActionBar.Theme;
+import org.telegram.ui.Cells.ChatMessageCell;
+import org.telegram.ui.Components.BackgroundGradientDrawable;
+import org.telegram.ui.Components.LayoutHelper;
+import org.telegram.ui.Components.MotionBackgroundDrawable;
+
+import tw.nekomimi.nekogram.NekoConfig;
+import tw.nekomimi.nekogram.helpers.TimeStringHelper;
+import xyz.nextalone.nagram.NaConfig;
+
+@SuppressLint("ViewConstructor")
+public class MessagesPreviewCell extends LinearLayout {
+
+    private final INavigationLayout parentLayout;
+    private final ChatMessageCell[] cells = new ChatMessageCell[2];
+    private final MessageObject[] messages = new MessageObject[2];
+    private final Runnable refreshRunnable = this::refreshMessages;
+    private final SharedPreferences.OnSharedPreferenceChangeListener preferencesListener = (preferences, key) -> {
+        if (isPreviewSetting(key)) {
+            removeCallbacks(refreshRunnable);
+            post(refreshRunnable);
+        }
+    };
+    private Boolean showSeconds;
+    private Drawable backgroundDrawable;
+    private Drawable oldBackgroundDrawable;
+    private BackgroundGradientDrawable.Disposable backgroundGradientDisposable;
+    private BackgroundGradientDrawable.Disposable oldBackgroundGradientDisposable;
+
+    public MessagesPreviewCell(Context context, INavigationLayout parentLayout, int account) {
+        super(context);
+        this.parentLayout = parentLayout;
+        setWillNotDraw(false);
+        setOrientation(VERTICAL);
+        setPadding(0, AndroidUtilities.dp(11), 0, AndroidUtilities.dp(11));
+
+        int date = (int) (System.currentTimeMillis() / 1000) - 3600;
+        TLRPC.TL_message text = createMessage(account, 42, date);
+        String markedText = LocaleController.getString(R.string.MessagePreviewText);
+        int spoilerStart = markedText.indexOf("||");
+        int spoilerEnd = spoilerStart < 0 ? -1 : markedText.indexOf("||", spoilerStart + 2);
+        if (spoilerEnd > spoilerStart) {
+            text.message = markedText.substring(0, spoilerStart)
+                    + markedText.substring(spoilerStart + 2, spoilerEnd)
+                    + markedText.substring(spoilerEnd + 2);
+            TLRPC.TL_messageEntitySpoiler spoiler = new TLRPC.TL_messageEntitySpoiler();
+            spoiler.offset = spoilerStart;
+            spoiler.length = spoilerEnd - spoilerStart - 2;
+            text.entities.add(spoiler);
+            text.flags |= TLRPC.MESSAGE_FLAG_HAS_ENTITIES;
+        } else {
+            text.message = markedText;
+        }
+        text.flags |= TLRPC.MESSAGE_FLAG_EDITED | TLRPC.MESSAGE_FLAG_FWD | TLRPC.MESSAGE_FLAG_HAS_VIEWS;
+        text.edit_date = date + 60;
+        text.views = 128;
+        text.forwards = 12;
+        text.fwd_from = new TLRPC.TL_messageFwdHeader();
+        text.fwd_from.flags = 32;
+        text.fwd_from.from_name = "Nagram";
+        text.fwd_from.date = date - 86400;
+        messages[0] = new MessageObject(account, text, true, false);
+
+        TLRPC.TL_message pollMessage = createMessage(account, 43, date + 120);
+        pollMessage.flags |= TLRPC.MESSAGE_FLAG_HAS_MEDIA;
+        TLRPC.TL_messageMediaPoll media = new TLRPC.TL_messageMediaPoll();
+        media.poll = new TLRPC.TL_poll();
+        media.poll.id = 1;
+        media.poll.question.text = LocaleController.getString(R.string.MessagePreviewPollQuestion);
+        media.results = new TLRPC.TL_pollResults();
+        media.results.flags = 2 | 4;
+        media.results.total_voters = 10;
+        int[] answers = {R.string.MessagePreviewPollAnswerTerrible, R.string.MessagePreviewPollAnswerWorse};
+        for (int i = 0; i < answers.length; i++) {
+            TLRPC.TL_pollAnswer answer = new TLRPC.TL_pollAnswer();
+            answer.text = new TLRPC.TL_textWithEntities();
+            answer.text.text = LocaleController.getString(answers[i]);
+            answer.option = new byte[]{(byte) i};
+            media.poll.answers.add(answer);
+            TLRPC.TL_pollAnswerVoters voters = new TLRPC.TL_pollAnswerVoters();
+            voters.option = answer.option;
+            voters.voters = i == 0 ? 7 : 3;
+            media.results.results.add(voters);
+        }
+        pollMessage.media = media;
+        messages[1] = new MessageObject(account, pollMessage, true, false);
+
+        TimeStringHelper.getForwardsDrawable();
+        for (int i = 0; i < cells.length; i++) {
+            messages[i].customName = "Nagram";
+            cells[i] = new ChatMessageCell(context, account);
+            cells[i].setDelegate(new ChatMessageCell.ChatMessageCellDelegate() {
+                @Override
+                public boolean canPerformActions() {
+                    return false;
+                }
+            });
+            cells[i].isChat = true;
+            cells[i].setFullyDraw(true);
+            addView(cells[i], LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT));
+        }
+        refreshMessages();
+    }
+
+    private static TLRPC.TL_message createMessage(int account, int id, int date) {
+        TLRPC.TL_message message = new TLRPC.TL_message();
+        message.id = id;
+        message.date = date;
+        message.dialog_id = 1;
+        message.flags = TLRPC.MESSAGE_FLAG_HAS_FROM_ID;
+        message.from_id = new TLRPC.TL_peerUser();
+        message.from_id.user_id = UserConfig.getInstance(account).getClientUserId();
+        message.peer_id = new TLRPC.TL_peerUser();
+        message.media = new TLRPC.TL_messageMediaEmpty();
+        message.message = "";
+        return message;
+    }
+
+    private static boolean isPreviewSetting(String key) {
+        return NekoConfig.showSeconds.getKey().equals(key)
+                || NaConfig.INSTANCE.getShowMessageID().getKey().equals(key)
+                || NaConfig.INSTANCE.getDateOfForwardedMsg().getKey().equals(key)
+                || NaConfig.INSTANCE.getShowEditedIcon().getKey().equals(key)
+                || NaConfig.INSTANCE.getCustomEditedMessage().getKey().equals(key)
+                || NaConfig.INSTANCE.getShowVoteCountBeforeVote().getKey().equals(key)
+                || NekoConfig.showSpoilersDirectly.getKey().equals(key);
+    }
+
+    public void refreshMessages() {
+        if (showSeconds == null || showSeconds != NekoConfig.showSeconds.Bool()) {
+            showSeconds = NekoConfig.showSeconds.Bool();
+            LocaleController.getInstance().recreateFormatters();
+        }
+        for (int i = 0; i < cells.length; i++) {
+            messages[i].isSpoilersRevealed = NekoConfig.showSpoilersDirectly.Bool();
+            messages[i].resetLayout();
+            messages[i].forceUpdate = true;
+            cells[i].setMessageObject(messages[i], null, false, false, false);
+            cells[i].requestLayout();
+        }
+        requestLayout();
+        invalidate();
+    }
+
+    @Override
+    public void invalidate() {
+        super.invalidate();
+        if (cells != null) {
+            for (ChatMessageCell cell : cells) {
+                if (cell != null) {
+                    cell.invalidate();
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        NekoConfig.preferences.registerOnSharedPreferenceChangeListener(preferencesListener);
+        refreshMessages();
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        Drawable newDrawable = Theme.getCachedWallpaperNonBlocking();
+        if (newDrawable != null && newDrawable != backgroundDrawable) {
+            if (oldBackgroundGradientDisposable != null) {
+                oldBackgroundGradientDisposable.dispose();
+                oldBackgroundGradientDisposable = null;
+            }
+            oldBackgroundDrawable = null;
+            if (Theme.isAnimatingColor()) {
+                oldBackgroundDrawable = backgroundDrawable;
+                oldBackgroundGradientDisposable = backgroundGradientDisposable;
+            } else if (backgroundGradientDisposable != null) {
+                backgroundGradientDisposable.dispose();
+            }
+            backgroundGradientDisposable = null;
+            backgroundDrawable = newDrawable;
+        }
+
+        float progress = parentLayout == null ? 1f : parentLayout.getThemeAnimationValue();
+        for (int i = 0; i < 2; i++) {
+            Drawable drawable = i == 0 ? oldBackgroundDrawable : backgroundDrawable;
+            if (drawable == null) {
+                continue;
+            }
+            int alpha = drawable.getAlpha();
+            drawable.setAlpha(i == 1 && oldBackgroundDrawable != null ? (int) (255 * progress) : 255);
+            if (drawable instanceof ColorDrawable || drawable instanceof GradientDrawable || drawable instanceof MotionBackgroundDrawable) {
+                drawable.setBounds(0, 0, getMeasuredWidth(), getMeasuredHeight());
+                if (drawable instanceof BackgroundGradientDrawable) {
+                    BackgroundGradientDrawable.Disposable disposable = ((BackgroundGradientDrawable) drawable).drawExactBoundsSize(canvas, this);
+                    if (i == 0) {
+                        oldBackgroundGradientDisposable = disposable;
+                    } else {
+                        backgroundGradientDisposable = disposable;
+                    }
+                } else {
+                    drawable.draw(canvas);
+                }
+            } else if (drawable instanceof BitmapDrawable) {
+                BitmapDrawable bitmap = (BitmapDrawable) drawable;
+                canvas.save();
+                if (bitmap.getTileModeX() == Shader.TileMode.REPEAT) {
+                    float scale = 2f / AndroidUtilities.density;
+                    canvas.scale(scale, scale);
+                    drawable.setBounds(0, 0, (int) Math.ceil(getMeasuredWidth() / scale), (int) Math.ceil(getMeasuredHeight() / scale));
+                } else {
+                    float scale = Math.max((float) getMeasuredWidth() / drawable.getIntrinsicWidth(), (float) getMeasuredHeight() / drawable.getIntrinsicHeight());
+                    int width = (int) Math.ceil(drawable.getIntrinsicWidth() * scale);
+                    int height = (int) Math.ceil(drawable.getIntrinsicHeight() * scale);
+                    int x = (getMeasuredWidth() - width) / 2;
+                    int y = (getMeasuredHeight() - height) / 2;
+                    canvas.clipRect(0, 0, getMeasuredWidth(), getMeasuredHeight());
+                    drawable.setBounds(x, y, x + width, y + height);
+                }
+                drawable.draw(canvas);
+                canvas.restore();
+            }
+            drawable.setAlpha(alpha);
+        }
+        if (oldBackgroundDrawable != null && progress >= 1f) {
+            oldBackgroundDrawable = null;
+            if (oldBackgroundGradientDisposable != null) {
+                oldBackgroundGradientDisposable.dispose();
+                oldBackgroundGradientDisposable = null;
+            }
+        }
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        NekoConfig.preferences.unregisterOnSharedPreferenceChangeListener(preferencesListener);
+        removeCallbacks(refreshRunnable);
+        if (backgroundGradientDisposable != null) {
+            backgroundGradientDisposable.dispose();
+            backgroundGradientDisposable = null;
+        }
+        if (oldBackgroundGradientDisposable != null) {
+            oldBackgroundGradientDisposable.dispose();
+            oldBackgroundGradientDisposable = null;
+        }
+        oldBackgroundDrawable = null;
+        super.onDetachedFromWindow();
+    }
+
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent event) {
+        return false;
+    }
+
+    @Override
+    protected void dispatchSetPressed(boolean pressed) {
+    }
+}

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/MessagesPreviewCell.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/MessagesPreviewCell.java
@@ -12,6 +12,8 @@ import android.graphics.drawable.GradientDrawable;
 import android.view.MotionEvent;
 import android.widget.LinearLayout;
 
+import androidx.annotation.NonNull;
+
 import org.telegram.messenger.AndroidUtilities;
 import org.telegram.messenger.LocaleController;
 import org.telegram.messenger.MessageObject;
@@ -112,13 +114,18 @@ public class MessagesPreviewCell extends LinearLayout {
         for (int i = 0; i < cells.length; i++) {
             messages[i].customName = "Nagram";
             messages[i].forceAvatar = true;
-            cells[i] = new ChatMessageCell(context, account);
-            cells[i].setDelegate(new ChatMessageCell.ChatMessageCellDelegate() {
+            cells[i] = new ChatMessageCell(context, account) {
                 @Override
-                public boolean canPerformActions() {
-                    return false;
+                protected void dispatchDraw(@NonNull Canvas canvas) {
+                    if (getAvatarImage() != null && getAvatarImage().getImageHeight() != 0) {
+                        getAvatarImage().setImageCoords(getAvatarImage().getImageX(), getMeasuredHeight() - getAvatarImage().getImageHeight() - AndroidUtilities.dp(4), getAvatarImage().getImageWidth(), getAvatarImage().getImageHeight());
+                        getAvatarImage().setRoundRadius((int) (getAvatarImage().getImageHeight() / 2f));
+                        getAvatarImage().draw(canvas);
+                    }
+                    super.dispatchDraw(canvas);
                 }
-            });
+            };
+            cells[i].setDelegate(new ChatMessageCell.ChatMessageCellDelegate() {});
             cells[i].isChat = true;
             cells[i].setFullyDraw(true);
             addView(cells[i], LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT));

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
@@ -412,6 +412,8 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
                 LocaleController.getInstance().recreateFormatters();
             } else if (key.equals(NaConfig.INSTANCE.getDisableBotOpenButton().getKey())) {
                 tooltip.showWithAction(0, UndoView.ACTION_NEED_RESATRT, null, null);
+            } else if (key.equals(NekoConfig.hideTimeForSticker.getKey()) || key.equals(NaConfig.INSTANCE.getRealHideTimeForSticker().getKey())) {
+                if (stickerSizeCell != null) stickerSizeCell.invalidate();
             }
         };
 

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
@@ -94,7 +94,6 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
     private final AbstractConfigCell dividerMessages = cellGroup.appendCell(new ConfigCellDivider());
 
     private final AbstractConfigCell doubleTapActionRow = cellGroup.appendCell(new ConfigCellCustom("DoubleTapAction", CellGroup.ITEM_TYPE_TEXT_SETTINGS_CELL, true));
-    private final AbstractConfigCell disableReactionsWhenSelectingRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.disableReactionsWhenSelecting));
     private final AbstractConfigCell dividerDoubleTap = cellGroup.appendCell(new ConfigCellDivider());
 
     // Chats
@@ -247,6 +246,11 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
     private final AbstractConfigCell dontSendGreetingStickerRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.dontSendGreetingSticker));
     private final AbstractConfigCell removeFavouriteStickersInRecentStickersRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getRemoveFavouriteStickersInRecentStickers()));
     private final AbstractConfigCell dividerSticker = cellGroup.appendCell(new ConfigCellDivider());
+
+    // Reaction
+    private final AbstractConfigCell headerReaction = cellGroup.appendCell(new ConfigCellHeader(LocaleController.getString("ReactionSettings", R.string.ReactionSettings)));
+    private final AbstractConfigCell disableReactionsWhenSelectingRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.disableReactionsWhenSelecting));
+    private final AbstractConfigCell dividerReaction = cellGroup.appendCell(new ConfigCellDivider());
 
     // Operation Confirmatation
     private final AbstractConfigCell headerConfirms = cellGroup.appendCell(new ConfigCellHeader(LocaleController.getString("ConfirmSettings")));

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
@@ -94,6 +94,7 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
     private final AbstractConfigCell dividerMessages = cellGroup.appendCell(new ConfigCellDivider());
 
     private final AbstractConfigCell doubleTapActionRow = cellGroup.appendCell(new ConfigCellCustom("DoubleTapAction", CellGroup.ITEM_TYPE_TEXT_SETTINGS_CELL, true));
+    private final AbstractConfigCell disableReactionsWhenSelectingRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.disableReactionsWhenSelecting));
     private final AbstractConfigCell dividerDoubleTap = cellGroup.appendCell(new ConfigCellDivider());
 
     // Chats
@@ -246,18 +247,6 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
     private final AbstractConfigCell dontSendGreetingStickerRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.dontSendGreetingSticker));
     private final AbstractConfigCell removeFavouriteStickersInRecentStickersRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getRemoveFavouriteStickersInRecentStickers()));
     private final AbstractConfigCell dividerSticker = cellGroup.appendCell(new ConfigCellDivider());
-
-    // Reaction
-    private final AbstractConfigCell headerReaction = cellGroup.appendCell(new ConfigCellHeader(LocaleController.getString("ReactionSettings", R.string.ReactionSettings)));
-//    private final AbstractConfigCell reactionsRow = cellGroup.appendCell(new ConfigCellSelectBox(LocaleController.getString("DoubleTapAndReactions", R.string.doubleTapAndReactions),
-//            NekoConfig.reactions,
-//            new String[]{
-//                    LocaleController.getString("doubleTapSendReaction", R.string.doubleTapSendReaction),
-//                    LocaleController.getString("doubleTapShowReactionsMenu", R.string.doubleTapShowReactionsMenu),
-//                    LocaleController.getString("doubleTapDisable", R.string.doubleTapDisable),
-//            }, null));
-    private final AbstractConfigCell disableReactionsWhenSelectingRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.disableReactionsWhenSelecting));
-    private final AbstractConfigCell dividerReaction = cellGroup.appendCell(new ConfigCellDivider());
 
     // Operation Confirmatation
     private final AbstractConfigCell headerConfirms = cellGroup.appendCell(new ConfigCellHeader(LocaleController.getString("ConfirmSettings")));

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
@@ -81,6 +81,21 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
     private final AbstractConfigCell hideGroupStickerRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.hideGroupSticker));
     private final AbstractConfigCell dividerStickerOptions = cellGroup.appendCell(new ConfigCellDivider());
 
+    // Messages
+    private final AbstractConfigCell headerMessages = cellGroup.appendCell(new ConfigCellHeader(LocaleController.getString(R.string.NagramMessages)));
+    private final AbstractConfigCell messagesPreviewRow = cellGroup.appendCell(new ConfigCellCustom("MessagePreview", ConfigCellCustom.CUSTOM_ITEM_MessagesPreview, false));
+    private final AbstractConfigCell showSeconds = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.showSeconds));
+    private final AbstractConfigCell showMessageIDRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getShowMessageID()));
+    private final AbstractConfigCell dateOfForwardMsgRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getDateOfForwardedMsg()));
+    private final AbstractConfigCell showEditedIconRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getShowEditedIcon()));
+    private final AbstractConfigCell customEditedMessageRow = cellGroup.appendCell(new ConfigCellTextInput(null, NaConfig.INSTANCE.getCustomEditedMessage(), "", null, null, false));
+    private final AbstractConfigCell showVoteCountBeforeVoteRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getShowVoteCountBeforeVote()));
+    private final AbstractConfigCell showSpoilersDirectlyRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.showSpoilersDirectly));
+    private final AbstractConfigCell dividerMessages = cellGroup.appendCell(new ConfigCellDivider());
+
+    private final AbstractConfigCell doubleTapActionRow = cellGroup.appendCell(new ConfigCellCustom("DoubleTapAction", CellGroup.ITEM_TYPE_TEXT_SETTINGS_CELL, true));
+    private final AbstractConfigCell dividerDoubleTap = cellGroup.appendCell(new ConfigCellDivider());
+
     // Chats
     private final AbstractConfigCell header1 = cellGroup.appendCell(new ConfigCellHeader(LocaleController.getString("Chat")));
     private final AbstractConfigCell emojiSetsRow = cellGroup.appendCell(new ConfigCellCustom("EmojiSet", ConfigCellCustom.CUSTOM_ITEM_EmojiSet, true));
@@ -92,11 +107,9 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
     private final AbstractConfigCell disableLinkPreviewByDefaultRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.disableLinkPreviewByDefault, LocaleController.getString("DisableLinkPreviewByDefaultNotice")));
     private final AbstractConfigCell takeGIFasVideoRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.takeGIFasVideo));
     private final AbstractConfigCell showSmallGifRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getShowSmallGIF()));
-    private final AbstractConfigCell showSeconds = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.showSeconds));
     private final AbstractConfigCell showBottomActionsWhenSelectingRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.showBottomActionsWhenSelecting));
     private final AbstractConfigCell labelChannelUserRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.labelChannelUser));
     private final AbstractConfigCell hideSendAsChannelRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.hideSendAsChannel));
-    private final AbstractConfigCell showSpoilersDirectlyRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.showSpoilersDirectly));
     private final AbstractConfigCell messageMenuRow = cellGroup.appendCell(new ConfigCellSelectBox("MessageMenu", null, null, () -> {
         if (getParentActivity() == null) return;
         showMessageMenuAlert();
@@ -123,16 +136,12 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
     }));
     private final AbstractConfigCell customGreatRow = cellGroup.appendCell(new ConfigCellTextInput(null, NaConfig.INSTANCE.getCustomGreat(), LocaleController.getString(R.string.CustomGreatHint), null,(input) -> input.isEmpty() ? (String) NaConfig.INSTANCE.getCustomGreat().defaultValue : input));
     private final AbstractConfigCell customPoorRow = cellGroup.appendCell(new ConfigCellTextInput(null, NaConfig.INSTANCE.getCustomPoor(), LocaleController.getString(R.string.CustomPoorHint), null,(input) -> input.isEmpty() ? (String) NaConfig.INSTANCE.getCustomPoor().defaultValue : input));
-    private final AbstractConfigCell showEditedIconRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getShowEditedIcon()));
-    private final AbstractConfigCell customEditedMessageRow = cellGroup.appendCell(new ConfigCellTextInput(null, NaConfig.INSTANCE.getCustomEditedMessage(), "", null));
     private final AbstractConfigCell showServicesTime = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getShowServicesTime()));
 //    private final AbstractConfigCell combineMessageRow = cellGroup.appendCell(new ConfigCellSelectBox(null, NaConfig.INSTANCE.getCombineMessage(), new String[]{
 //            LocaleController.getString("combineMessageEnabledWithReply", R.string.CombineMessageEnabledWithReply),
 //            LocaleController.getString("combineMessageEnabled", R.string.CombineMessageEnabled),
 //            LocaleController.getString("combineMessageDisabled", R.string.CombineMessageDisabled)
 //    }, null));
-    private final AbstractConfigCell dateOfForwardMsgRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getDateOfForwardedMsg()));
-    private final AbstractConfigCell showMessageIDRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getShowMessageID()));
     private final AbstractConfigCell showPremiumStarInChatRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getShowPremiumStarInChat()));
     private final AbstractConfigCell showPremiumAvatarAnimationRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getShowPremiumAvatarAnimation()));
     private final AbstractConfigCell alwaysSaveChatOffsetRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getAlwaysSaveChatOffset()));
@@ -147,7 +156,6 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
 //                    LocaleController.getString("MapPreviewProviderYandex", R.string.MapPreviewProviderYandex),
 //                    LocaleController.getString("MapPreviewProviderNobody", R.string.MapPreviewProviderNobody)
 //            }, null));
-    private final AbstractConfigCell doubleTapActionRow = cellGroup.appendCell(new ConfigCellCustom("DoubleTapAction", CellGroup.ITEM_TYPE_TEXT_SETTINGS_CELL, true));
     private final AbstractConfigCell autoReplaceRepeatRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getAutoReplaceRepeat()));
     private final AbstractConfigCell textStyleRow = cellGroup.appendCell(new ConfigCellSelectBox("TextStyle", null, null, () -> {
         if (getParentActivity() == null) return;
@@ -173,7 +181,6 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
     private final AbstractConfigCell disableCustomWallpaperChannelRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getDisableCustomWallpaperChannel()));
     private final AbstractConfigCell coloredAdminTitleRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getColoredAdminTitle()));
     private final AbstractConfigCell disableRepeatInChannelRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getDisableRepeatInChannel()));
-    private final AbstractConfigCell showVoteCountBeforeVoteRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getShowVoteCountBeforeVote()));
     private final AbstractConfigCell dividerChat = cellGroup.appendCell(new ConfigCellDivider());
 
     // Interactions
@@ -325,7 +332,7 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
 
         listView.setAdapter(listAdapter);
         listView.setItemSelectorColorProvider(position ->
-                position == cellGroup.rows.indexOf(stickerSizeRow) ? Color.TRANSPARENT : null);
+                position == cellGroup.rows.indexOf(stickerSizeRow) || position == cellGroup.rows.indexOf(messagesPreviewRow) ? Color.TRANSPARENT : null);
         // Fragment: Set OnClick Callbacks
         listView.setOnItemClickListener((view, position, x, y) -> {
             AbstractConfigCell a = cellGroup.rows.get(position);
@@ -409,7 +416,7 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
             } else if (key.equals(NekoConfig.disableProximityEvents.getKey())) {
                 MediaController.getInstance().recreateProximityWakeLock();
             } else if (key.equals(NekoConfig.showSeconds.getKey())) {
-                tooltip.showWithAction(0, UndoView.ACTION_NEED_RESATRT, null, null);
+                LocaleController.getInstance().recreateFormatters();
             } else if (key.equals(NaConfig.INSTANCE.getDisableBotOpenButton().getKey())) {
                 tooltip.showWithAction(0, UndoView.ACTION_NEED_RESATRT, null, null);
             }
@@ -630,6 +637,8 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
                     } else if (view instanceof EmojiSetCell) {
                         EmojiSetCell v1 =  (EmojiSetCell) view;
                         v1.setData(EmojiHelper.getInstance().getCurrentEmojiPackInfo(), false, divider);
+                    } else if (view instanceof MessagesPreviewCell) {
+                        ((MessagesPreviewCell) view).refreshMessages();
                     }
                 } else {
                     // Default binds
@@ -647,6 +656,9 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
                     break;
                 case ConfigCellCustom.CUSTOM_ITEM_EmojiSet:
                     view = emojiSetCell = new EmojiSetCell(mContext, false);
+                    break;
+                case ConfigCellCustom.CUSTOM_ITEM_MessagesPreview:
+                    view = new MessagesPreviewCell(mContext, parentLayout, currentAccount);
                     break;
             }
             if (view != null) {

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
@@ -359,4 +359,9 @@
     <string name="DisableGooeyAvatarAnimation">禁用“Gooey”头像动画</string>
     <string name="ForceVideoNewRewindMethod">强制所有视频使用新版快进方式</string>
     <string name="TabStyleStroke">标签指示器描边</string>
+    <string name="NagramMessages">消息</string>
+    <string name="MessagePreviewText">既然我想让代码变得糟糕，那就靠||感觉编程||吧。</string>
+    <string name="MessagePreviewPollQuestion">代码怎么样？</string>
+    <string name="MessagePreviewPollAnswerTerrible">很糟糕</string>
+    <string name="MessagePreviewPollAnswerWorse">更糟糕</string>
 </resources>

--- a/TMessagesProj/src/main/res/values-zh-rTW/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rTW/strings_na.xml
@@ -357,4 +357,9 @@
     <string name="LiquidGlassAngle">Liquid Glass angle</string>
     <string name="LiquidGlassIntensity">Liquid Glass intensity</string>
     <string name="DisableGooeyAvatarAnimation">Disable \"Gooey\" avatar animation</string>
+    <string name="NagramMessages">訊息</string>
+    <string name="MessagePreviewText">既然我想讓程式碼變得糟糕，那就靠||感覺寫程式||吧。</string>
+    <string name="MessagePreviewPollQuestion">程式碼怎麼樣？</string>
+    <string name="MessagePreviewPollAnswerTerrible">很糟糕</string>
+    <string name="MessagePreviewPollAnswerWorse">更糟糕</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -361,4 +361,9 @@
     <string name="ForceVideoNewRewindMethod">Force video use new seek method</string>
     <string name="TabStyleStroke">Tab indicator outline</string>
     <string name="AddCommaAfterMention">Add Comma after Mention</string>
+    <string name="NagramMessages">Messages</string>
+    <string name="MessagePreviewText">since i want the code to be terrible i am ||vibe-coding||</string>
+    <string name="MessagePreviewPollQuestion">How is the code?</string>
+    <string name="MessagePreviewPollAnswerTerrible">Terrible</string>
+    <string name="MessagePreviewPollAnswerWorse">Even worse</string>
 </resources>


### PR DESCRIPTION
message preview and grouping of message-related settings

## Summary by Sourcery

Add a live message preview and organize related chat display options into a dedicated settings section.

New Features:
- Add a live message preview to chat settings, showing representative text and poll messages with formatting, forwarding, editing, spoiler, and voting indicators.

Enhancements:
- Group message-related chat options into a dedicated Messages settings section and update previews as relevant preferences change.
- Allow text input settings to opt out of rebuilding the entire settings view after changes.

Chores:
- Add localized labels and sample preview content for supported languages.