### PR TITLE
feat: show info when badge is clicked

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/tgnet/TLRPC.java
+++ b/TMessagesProj/src/main/java/org/telegram/tgnet/TLRPC.java
@@ -21413,8 +21413,16 @@ public class TLRPC {
         public long fromMessageDialogId; //custom
         public int fromMessageId; //custom
 
+        public boolean isNagramDeveloper() {
+            return ArrayUtil.contains(NekoXConfig.developers, id);
+        }
+
+        public boolean isNagramOfficial() {
+            return ArrayUtil.contains(NekoXConfig.officialChats, id);
+        }
+
         public boolean verifiedExtended() {
-            return verified || (ArrayUtil.contains(NekoXConfig.developers, id) && NekoXConfig.isDeveloper());
+            return verified || ((ArrayUtil.contains(NekoXConfig.developers, id) || ArrayUtil.contains(NekoXConfig.officialChats, id)) && NekoXConfig.isDeveloper());
         }
 
         public static User TLdeserialize(InputSerializedData stream, int constructor, boolean exception) {
@@ -38897,8 +38905,16 @@ public class TLRPC {
 
         public ArrayList<TL_username> usernames = new ArrayList<>();
 
+        public boolean isNagramDeveloper() {
+            return ArrayUtil.contains(NekoXConfig.developers, id);
+        }
+
+        public boolean isNagramOfficial() {
+            return ArrayUtil.contains(NekoXConfig.officialChats, id);
+        }
+
         public boolean verifiedExtended() {
-            return verified ||( ArrayUtil.contains(NekoXConfig.officialChats, id) && NekoXConfig.isDeveloper());
+            return verified || ((ArrayUtil.contains(NekoXConfig.officialChats, id) || ArrayUtil.contains(NekoXConfig.developers, id)) && NekoXConfig.isDeveloper());
         }
 
         public static Chat TLdeserialize(InputSerializedData stream, int constructor, boolean exception) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/SimpleTextView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/SimpleTextView.java
@@ -98,6 +98,8 @@ public class SimpleTextView extends View implements Drawable.Callback {
     private int textHeight;
     public int rightDrawableX;
     public int rightDrawableY;
+    public int rightDrawable2X;
+    public int rightDrawable2Y;
     private boolean wasLayout;
 
     private boolean leftDrawableOutside, rightDrawableOutside;
@@ -128,6 +130,8 @@ public class SimpleTextView extends View implements Drawable.Callback {
     private boolean canHideRightDrawable;
     private boolean rightDrawableHidden;
     private OnClickListener rightDrawableOnClickListener;
+    private OnClickListener rightDrawable2OnClickListener;
+    private int clickedDrawable;
     private boolean maybeClick;
     private float touchDownX, touchDownY;
 
@@ -931,6 +935,8 @@ public class SimpleTextView extends View implements Drawable.Callback {
                 y = getPaddingTop() + (textHeight - dh) / 2 + rightDrawableTopPadding;
             }
             rightDrawable2.setBounds(x, y, x + dw, y + dh);
+            rightDrawable2X = x + (dw >> 1);
+            rightDrawable2Y = y + (dh >> 1);
             rightDrawable2.draw(canvas);
             totalWidth += drawablePadding + dw;
         }
@@ -977,6 +983,8 @@ public class SimpleTextView extends View implements Drawable.Callback {
                     y = getPaddingTop() + (textHeight - dh) / 2 + rightDrawableTopPadding;
                 }
                 rightDrawable2.setBounds(x, y, x + dw, y + dh);
+                rightDrawable2X = x + (dw >> 1);
+                rightDrawable2Y = y + (dh >> 1);
                 rightDrawable2.draw(canvas);
             }
         }
@@ -1072,6 +1080,8 @@ public class SimpleTextView extends View implements Drawable.Callback {
                     y = getPaddingTop() + (textHeight - dh) / 2 + rightDrawableTopPadding;
                 }
                 rightDrawable2.setBounds(x, y, x + dw, y + dh);
+                rightDrawable2X = x + (dw >> 1);
+                rightDrawable2Y = y + (dh >> 1);
                 rightDrawable2.draw(canvas);
                 totalWidth += drawablePadding + dw;
             }
@@ -1150,6 +1160,8 @@ public class SimpleTextView extends View implements Drawable.Callback {
                 y = getPaddingTop() + (textHeight - dh) / 2 + rightDrawableTopPadding;
             }
             rightDrawable2.setBounds(x, y, x + dw, y + dh);
+            rightDrawable2X = x + (dw >> 1);
+            rightDrawable2Y = y + (dh >> 1);
             rightDrawable2.draw(canvas);
         }
     }
@@ -1329,34 +1341,66 @@ public class SimpleTextView extends View implements Drawable.Callback {
         rightDrawableOnClickListener = onClickListener;
     }
 
+    public void setRightDrawable2OnClick(OnClickListener onClickListener) {
+        rightDrawable2OnClickListener = onClickListener;
+    }
+
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        if (rightDrawableOnClickListener != null && rightDrawable != null) {
-            AndroidUtilities.rectTmp.set(rightDrawableX - dp(16), rightDrawableY - dp(16), rightDrawableX + dp(16), rightDrawableY + dp(16));
-            if (event.getAction() == MotionEvent.ACTION_DOWN && AndroidUtilities.rectTmp.contains((int) event.getX(), (int) event.getY())) {
-                maybeClick = true;
-                touchDownX = event.getX();
-                touchDownY = event.getY();
-                getParent().requestDisallowInterceptTouchEvent(true);
-                if (rightDrawable instanceof PressableDrawable) {
-                    ((PressableDrawable) rightDrawable).setPressed(true);
+        if ((rightDrawableOnClickListener != null && rightDrawable != null) || (rightDrawable2OnClickListener != null && rightDrawable2 != null)) {
+            if (event.getAction() == MotionEvent.ACTION_DOWN) {
+                if (rightDrawableOnClickListener != null && rightDrawable != null) {
+                    AndroidUtilities.rectTmp.set(rightDrawableX - dp(16), rightDrawableY - dp(16), rightDrawableX + dp(16), rightDrawableY + dp(16));
+                    if (AndroidUtilities.rectTmp.contains((int) event.getX(), (int) event.getY())) {
+                        maybeClick = true;
+                        clickedDrawable = 1;
+                        touchDownX = event.getX();
+                        touchDownY = event.getY();
+                        getParent().requestDisallowInterceptTouchEvent(true);
+                        if (rightDrawable instanceof PressableDrawable) {
+                            ((PressableDrawable) rightDrawable).setPressed(true);
+                        }
+                    }
+                }
+                if (!maybeClick && rightDrawable2OnClickListener != null && rightDrawable2 != null) {
+                    AndroidUtilities.rectTmp.set(rightDrawable2X - dp(16), rightDrawable2Y - dp(16), rightDrawable2X + dp(16), rightDrawable2Y + dp(16));
+                    if (AndroidUtilities.rectTmp.contains((int) event.getX(), (int) event.getY())) {
+                        maybeClick = true;
+                        clickedDrawable = 2;
+                        touchDownX = event.getX();
+                        touchDownY = event.getY();
+                        getParent().requestDisallowInterceptTouchEvent(true);
+                        if (rightDrawable2 instanceof PressableDrawable) {
+                            ((PressableDrawable) rightDrawable2).setPressed(true);
+                        }
+                    }
                 }
             } else if (event.getAction() == MotionEvent.ACTION_MOVE && maybeClick) {
                 if (Math.abs(event.getX() - touchDownX) >= AndroidUtilities.touchSlop || Math.abs(event.getY() - touchDownY) >= AndroidUtilities.touchSlop) {
                     maybeClick = false;
                     getParent().requestDisallowInterceptTouchEvent(false);
-                    if (rightDrawable instanceof PressableDrawable) {
+                    if (clickedDrawable == 1 && rightDrawable instanceof PressableDrawable) {
                         ((PressableDrawable) rightDrawable).setPressed(false);
+                    } else if (clickedDrawable == 2 && rightDrawable2 instanceof PressableDrawable) {
+                        ((PressableDrawable) rightDrawable2).setPressed(false);
                     }
+                    clickedDrawable = 0;
                 }
             } else if (event.getAction() == MotionEvent.ACTION_UP || event.getAction() == MotionEvent.ACTION_CANCEL) {
                 if (maybeClick && event.getAction() == MotionEvent.ACTION_UP) {
-                    rightDrawableOnClickListener.onClick(this);
-                    if (rightDrawable instanceof PressableDrawable) {
+                    if (clickedDrawable == 1 && rightDrawableOnClickListener != null) {
+                        rightDrawableOnClickListener.onClick(this);
+                    } else if (clickedDrawable == 2 && rightDrawable2OnClickListener != null) {
+                        rightDrawable2OnClickListener.onClick(this);
+                    }
+                    if (clickedDrawable == 1 && rightDrawable instanceof PressableDrawable) {
                         ((PressableDrawable) rightDrawable).setPressed(false);
+                    } else if (clickedDrawable == 2 && rightDrawable2 instanceof PressableDrawable) {
+                        ((PressableDrawable) rightDrawable2).setPressed(false);
                     }
                 }
                 maybeClick = false;
+                clickedDrawable = 0;
                 getParent().requestDisallowInterceptTouchEvent(false);
             }
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -20388,19 +20388,26 @@ public class ChatActivity extends BaseFragment implements
         } else if (chatMode == MODE_PINNED) {
             avatarContainer.setTitle(LocaleController.formatPluralString("PinnedMessagesCount", getPinnedMessagesCount()));
         } else if (currentChat != null) {
-            avatarContainer.setTitle(AndroidUtilities.removeRTL(AndroidUtilities.removeDiacritics(currentChat.title)), currentChat.scam, currentChat.fake, currentChat.verified, false, currentChat.emoji_status, animated);
+            avatarContainer.setTitle(AndroidUtilities.removeRTL(AndroidUtilities.removeDiacritics(currentChat.title)), currentChat.scam, currentChat.fake, currentChat.verifiedExtended(), false, currentChat.emoji_status, animated);
         } else if (currentUser != null) {
             if (currentUser.self) {
                 avatarContainer.setTitle(LocaleController.getString(R.string.SavedMessages));
             } else if (!MessagesController.isSupportUser(currentUser) && getContactsController().contactsDict.get(currentUser.id) == null && (getContactsController().contactsDict.size() != 0 || !getContactsController().isLoadingContacts())) {
                 if (!TextUtils.isEmpty(currentUser.phone)) {
-                    avatarContainer.setTitle(PhoneFormat.getInstance().format("+" + currentUser.phone), currentUser.scam, currentUser.fake, currentUser.verified, getMessagesController().isPremiumUser(currentUser), currentUser.emoji_status, animated);
+                    avatarContainer.setTitle(PhoneFormat.getInstance().format("+" + currentUser.phone), currentUser.scam, currentUser.fake, currentUser.verifiedExtended(), getMessagesController().isPremiumUser(currentUser), currentUser.emoji_status, animated);
                 } else {
-                    avatarContainer.setTitle(AndroidUtilities.removeRTL(AndroidUtilities.removeDiacritics(UserObject.getUserName(currentUser))), currentUser.scam, currentUser.fake, currentUser.verified, getMessagesController().isPremiumUser(currentUser), currentUser.emoji_status, animated);
+                    avatarContainer.setTitle(AndroidUtilities.removeRTL(AndroidUtilities.removeDiacritics(UserObject.getUserName(currentUser))), currentUser.scam, currentUser.fake, currentUser.verifiedExtended(), getMessagesController().isPremiumUser(currentUser), currentUser.emoji_status, animated);
                 }
             } else {
-                avatarContainer.setTitle(AndroidUtilities.removeRTL(AndroidUtilities.removeDiacritics(UserObject.getUserName(currentUser))), currentUser.scam, currentUser.fake, currentUser.verified, getMessagesController().isPremiumUser(currentUser), !MessagesController.isSupportUser(currentUser) ? currentUser.emoji_status : null, animated);
+                avatarContainer.setTitle(AndroidUtilities.removeRTL(AndroidUtilities.removeDiacritics(UserObject.getUserName(currentUser))), currentUser.scam, currentUser.fake, currentUser.verifiedExtended(), getMessagesController().isPremiumUser(currentUser), !MessagesController.isSupportUser(currentUser) ? currentUser.emoji_status : null, animated);
             }
+        }
+        if ((currentChat != null && currentChat.verifiedExtended()) || (currentUser != null && currentUser.verifiedExtended())) {
+            avatarContainer.getTitleTextView().setRightDrawable2OnClick(v -> {
+                tw.nekomimi.nekogram.NekoXConfig.showVerifiedBulletin(ChatActivity.this, currentUser, currentChat);
+            });
+        } else {
+            avatarContainer.getTitleTextView().setRightDrawable2OnClick(null);
         }
         setParentActivityTitle(avatarContainer.getTitleTextView().getText());
         updateTitleIcons();

--- a/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
@@ -11982,7 +11982,7 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
                     if (user.scam || user.fake) {
                         nameTextView[a].setRightDrawable2(getScamDrawable(user.scam ? 0 : 1));
                         nameTextViewRightDrawable2ContentDescription = LocaleController.getString(R.string.ScamMessage);
-                    } else if (user.verified) {
+                    } else if (user.verifiedExtended()) {
                         nameTextView[a].setRightDrawable2(getVerifiedCrossfadeDrawable(a));
                         nameTextViewRightDrawable2ContentDescription = LocaleController.getString(R.string.AccDescrVerified);
                     } else if (getMessagesController().isDialogMuted(dialogId != 0 ? dialogId : userId, topicId)) {
@@ -12098,6 +12098,13 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
                         }
                         showDialog(premiumPreviewBottomSheet);
                     });
+                }
+                if (user != null && user.verifiedExtended()) {
+                    nameTextView[a].setRightDrawable2OnClick(v -> {
+                        tw.nekomimi.nekogram.NekoXConfig.showVerifiedBulletin(ProfileActivity.this, user, null);
+                    });
+                } else {
+                    nameTextView[a].setRightDrawable2OnClick(null);
                 }
             }
 
@@ -12338,7 +12345,7 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
                 } else if (!copyFromChatActivity) {
                     if (chat.scam || chat.fake) {
                         nameTextView[a].setRightDrawable2(getScamDrawable(chat.scam ? 0 : 1));
-                    } else if (chat.verified) {
+                    } else if (chat.verifiedExtended()) {
                         nameTextView[a].setRightDrawable2(getVerifiedCrossfadeDrawable(a));
                     } else if (getMessagesController().isDialogMuted(-chatId, topicId)) {
                         nameTextView[a].setRightDrawable2(getThemedDrawable(Theme.key_drawable_muteIconDrawable));
@@ -12351,6 +12358,13 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
                     } else {
                         nameTextView[a].setRightDrawable(null);
                     }
+                }
+                if (chat != null && chat.verifiedExtended()) {
+                    nameTextView[a].setRightDrawable2OnClick(v -> {
+                        tw.nekomimi.nekogram.NekoXConfig.showVerifiedBulletin(ProfileActivity.this, null, chat);
+                    });
+                } else {
+                    nameTextView[a].setRightDrawable2OnClick(null);
                 }
                 if (chat.bot_verification_icon != 0) {
                     nameTextView[a].setLeftDrawableOutside(true);

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoXConfig.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoXConfig.java
@@ -229,4 +229,27 @@ public class NekoXConfig {
     public static String getChannelAlias(long channelID) {
         return preferences.getString(NekoConfig.channelAliasPrefix + channelID, null);
     }
+
+    public static void showVerifiedBulletin(org.telegram.ui.ActionBar.BaseFragment fragment, org.telegram.tgnet.TLRPC.User user, org.telegram.tgnet.TLRPC.Chat chat) {
+        if (fragment == null) return;
+        String name = "";
+        boolean isOfficial = false;
+        boolean isDev = false;
+        if (user != null) {
+            name = org.telegram.messenger.UserObject.getUserName(user);
+            isDev = user.isNagramDeveloper();
+        } else if (chat != null) {
+            name = chat.title;
+            isOfficial = chat.isNagramOfficial();
+        }
+        String text;
+        if (isOfficial) {
+            text = LocaleController.formatString("NagramOfficialResource", R.string.NagramOfficialResource, name);
+        } else if (isDev) {
+            text = LocaleController.formatString("NagramDevelopmentTeamMember", R.string.NagramDevelopmentTeamMember, name);
+        } else {
+            text = LocaleController.formatString("TelegramVerifiedAccount", R.string.TelegramVerifiedAccount, name);
+        }
+        org.telegram.ui.Components.BulletinFactory.of(fragment).createSimpleBulletin(R.raw.info, text).show();
+    }
 }

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -361,4 +361,7 @@
     <string name="ForceVideoNewRewindMethod">Force video use new seek method</string>
     <string name="TabStyleStroke">Tab indicator outline</string>
     <string name="AddCommaAfterMention">Add Comma after Mention</string>
+    <string name="NagramOfficialResource">%1$s is the official resource of Nagram.</string>
+    <string name="NagramDevelopmentTeamMember">%1$s is a member of the Nagram development team.</string>
+    <string name="TelegramVerifiedAccount">%1$s is verified as official by Telegram.</string>
 </resources>


### PR DESCRIPTION
Thank to Claude Desktop.

## Summary by Sourcery

Add interactive verification badges that explain the verification status of users and chats.

New Features:
- Show explanatory bulletins when users or chats’ verification badges are clicked.
- Support click handling for a second drawable in SimpleTextView.
- Classify verified accounts as Nagram developers, official resources, or Telegram-verified entities.

Enhancements:
- Use extended verification status for chat and profile badges, including configured Nagram developers and official chats.