### PR TITLE
fix: Skip camera permission if HideInstantCamera is true

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPhotoLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatAttachAlertPhotoLayout.java
@@ -3988,7 +3988,7 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
     }
 
     public void setCheckCameraWhenShown(boolean checkCameraWhenShown) {
-        this.checkCameraWhenShown = checkCameraWhenShown && !NekoConfig.disableInstantCamera.Bool();
+        this.checkCameraWhenShown = checkCameraWhenShown && !NekoConfig.disableInstantCamera.Bool() && !NaConfig.INSTANCE.getHideInstantCamera().Bool();
     }
 
     @Override
@@ -4204,7 +4204,7 @@ public class ChatAttachAlertPhotoLayout extends ChatAttachAlert.AttachAlertLayou
 
     @Override
     public void onOpenAnimationEnd() {
-        checkCamera(parentAlert != null && parentAlert.baseFragment instanceof ChatActivity && !NekoConfig.disableInstantCamera.Bool());
+        checkCamera(parentAlert != null && parentAlert.baseFragment instanceof ChatActivity && !NekoConfig.disableInstantCamera.Bool() && !NaConfig.INSTANCE.getHideInstantCamera().Bool());
     }
 
     @Override


### PR DESCRIPTION
Hi, I found it annoying, if I have Hide Instant Camera enabled, and it will ask me to grant camera permission for just opening the gallery.

Similar to:
https://github.com/NextAlone/Nagram/pull/88

## Summary by Sourcery

Bug Fixes:
- Prevent camera permission checks when the instant camera is hidden, avoiding unnecessary permission prompts when opening the gallery.