### PR TITLE
Fix "Repeat one" latching onto the wrong track, and missing cover art in the expanded player

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
@@ -1696,6 +1696,7 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
         cleanupPlayer(true, true);
         audioInfo = null;
         playMusicAgain = false;
+        forceLoopCurrentPlaylist = false;
         for (int a : SharedConfig.activeAccounts) {
             DownloadController.getInstance(a).cleanup();
         }
@@ -2879,10 +2880,6 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
 
     public boolean setPlaylist(ArrayList<MessageObject> messageObjects, MessageObject current, long mergeDialogId, boolean loadMusic, PlaylistGlobalSearchParams params) {
         if (playingMessageObject == current) {
-            int newIdx = playlist.indexOf(current);
-            if (newIdx >= 0) {
-                currentPlaylistNum = newIdx;
-            }
             return playMessage(current);
         }
         forceLoopCurrentPlaylist = !loadMusic;
@@ -2967,7 +2964,7 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
     }
 
     public void playMessageAtIndex(int index) {
-        if (currentPlaylistNum < 0 || currentPlaylistNum >= playlist.size()) {
+        if (index < 0 || index >= playlist.size()) {
             return;
         }
         currentPlaylistNum = index;
@@ -2979,15 +2976,29 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
         playMessage(messageObject);
     }
 
+    private void updateCurrentPlaylistNum(MessageObject messageObject) {
+        if (messageObject == null || !messageObject.isMusic()) {
+            return;
+        }
+        ArrayList<MessageObject> currentPlayList = SharedConfig.shuffleMusic ? shuffledPlaylist : playlist;
+        int index = currentPlayList.indexOf(messageObject);
+        if (index >= 0) {
+            currentPlaylistNum = index;
+        }
+    }
+
     private void playNextMessageWithoutOrder(boolean byStop) {
         ArrayList<MessageObject> currentPlayList = SharedConfig.shuffleMusic ? shuffledPlaylist : playlist;
 
-        if (byStop && (SharedConfig.repeatMode == 2 || SharedConfig.repeatMode == 1 && currentPlayList.size() == 1) && !forceLoopCurrentPlaylist) {
-            cleanupPlayer(false, false);
-            if (currentPlaylistNum < 0 || currentPlaylistNum >= currentPlayList.size()) {
-                return;
+        if (byStop && (SharedConfig.repeatMode == 2 || SharedConfig.repeatMode == 1 && currentPlayList.size() == 1)) {
+            MessageObject messageObject = playingMessageObject;
+            if (messageObject == null) {
+                if (currentPlaylistNum < 0 || currentPlaylistNum >= currentPlayList.size()) {
+                    return;
+                }
+                messageObject = currentPlayList.get(currentPlaylistNum);
             }
-            MessageObject messageObject = currentPlayList.get(currentPlaylistNum);
+            cleanupPlayer(false, false);
             messageObject.audioProgress = 0;
             messageObject.audioProgressSec = 0;
             playMessage(messageObject);
@@ -3653,6 +3664,7 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
         if (messageObject == null) {
             return false;
         }
+        updateCurrentPlaylistNum(messageObject);
         isSilent = silent;
         checkVolumeBarUI();
         if ((audioPlayer != null || videoPlayer != null) && isSamePlayingMessage(messageObject)) {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
@@ -2982,6 +2982,18 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
         }
         ArrayList<MessageObject> currentPlayList = SharedConfig.shuffleMusic ? shuffledPlaylist : playlist;
         int index = currentPlayList.indexOf(messageObject);
+        if (index < 0) {
+            // MessageObject overloads equals(MessageObject) but does not override
+            // equals(Object), so indexOf() compares by identity and misses an
+            // equivalent object coming from a rebuilt playlist.
+            for (int a = 0, N = currentPlayList.size(); a < N; a++) {
+                MessageObject object = currentPlayList.get(a);
+                if (object != null && object.getId() == messageObject.getId() && object.getDialogId() == messageObject.getDialogId()) {
+                    index = a;
+                    break;
+                }
+            }
+        }
         if (index >= 0) {
             currentPlaylistNum = index;
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/AudioPlayerAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/AudioPlayerAlert.java
@@ -2620,7 +2620,7 @@ public class AudioPlayerAlert extends BottomSheet implements NotificationCenter.
 
     private ImageLocation getArtworkThumbImageLocation(MessageObject messageObject) {
         final TLRPC.Document document = messageObject.getDocument();
-        TLRPC.PhotoSize thumb = document != null ? FileLoader.getClosestPhotoSizeWithSize(document.thumbs, 360) : null;
+        TLRPC.PhotoSize thumb = document != null ? FileLoader.getClosestPhotoSizeWithSize(document.thumbs, 360, false, null, true) : null;
         if (!(thumb instanceof TLRPC.TL_photoSize) && !(thumb instanceof TLRPC.TL_photoSizeProgressive)) {
             thumb = null;
         }


### PR DESCRIPTION
Two music player bugs inherited from upstream. Both reproduce on the current `main` (Telegram base 12.10.0). Both touched files are unmodified from upstream here, so the patch is not fork-specific.

## 1. "Repeat one" repeats the wrong track

**Symptom:** with *Repeat one* enabled, picking a new track does not repeat it. Playback walks the playlist track after track and eventually latches onto the track that was being repeated earlier, repeating that one instead.

**Cause:** `MediaController.playNextMessageWithoutOrder()` implemented repeat-one by replaying `currentPlayList.get(currentPlaylistNum)` rather than the track that actually just finished. `currentPlaylistNum` is maintained only by `setPlaylist()`, `traversePlaylist()` and the playlist-load handlers — `playMessage()` never updates it — so once the cached index drifts away from `playingMessageObject`, repeat-one latches onto whatever sits at the stale index.

Sources of the drift:

- **Two different index spaces.** `setPlaylist()` and `playMessageAtIndex()` stored an index into `playlist`, while `playNextMessageWithoutOrder()`, `playPreviousMessage()` and `checkIsNextMusicFileDownloaded()` read `shuffledPlaylist` at that same index. With shuffle on the two lists are ordered independently, so the index denotes a different song in each.
- **`playMessageAtIndex()` validated the wrong variable** — it range-checked the previous value of `currentPlaylistNum` instead of the `index` argument, so it could reject a valid request, or index the playlist out of bounds.
- **The resync in the load handlers is a no-op in practice.** `musicDidLoad` / `mediaDidLoad` / `musicListLoaded` resync via `playlist.indexOf(playingMessageObject)`. `MessageObject` overloads `equals(MessageObject)` but does not override `equals(Object)`, so `indexOf()` falls back to identity comparison and finds nothing once the list is repopulated with freshly built message objects.

**Fix:** repeat the `playingMessageObject` itself (captured before `cleanupPlayer()` nulls it), and resync `currentPlaylistNum` from the currently active list in `playMessage()`, so the index cannot drift out of its own index space.

### `forceLoopCurrentPlaylist` silently overrode the repeat setting

The same branch was additionally gated on `!forceLoopCurrentPlaylist`. That flag is set by every caller passing `loadMusic = false`:

- `ArticleViewer`, `RichAudioCell`, `RichMessageLayout` (Instant View audio)
- `TelegramMediaSession.onPlayFromMediaId` (media session — Android Auto and other external media browser clients)

Its purpose is *"this playlist is already complete, don't paginate it"*, but it also disabled repeat-one outright, so after playing from any of those entry points the playlist just looped and the user's explicit *Repeat one* choice was ignored. It no longer gates repeat-one, and it is now reset in `cleanup()` so it cannot leak into the next playlist.

## 2. Cover art missing in the expanded player

**Symptom:** a track shows its cover in the message bubble, but the expanded player shows no artwork.

**Cause:** `AudioPlayerAlert.getArtworkThumbImageLocation()` used `getClosestPhotoSizeWithSize(document.thumbs, 360)`, which leaves `ignoreStripped = false`. In `FileLoader.getClosestPhotoSizeWithSize()`, `closestObject` is seeded with the first candidate and only replaced when `currentSide <= side`, so for a track whose only real thumbnail is **larger than 360px** (common for embedded album art — 500×500, 640×640) the stripped placeholder is selected and kept. The following `TL_photoSize` / `TL_photoSizeProgressive` check then discards it, and the player falls back to `getArtworkUrl()`, which is `null` for a normally uploaded file — so no cover at all.

`ChatMessageCell` already passes `ignoreStripped = true`, which is exactly why the same track renders correctly in the bubble.

**Fix:** pass `ignoreStripped = true` here too, so the real thumbnail is selected instead of the placeholder. `preloadNeighboringThumbs()` uses the same helper and benefits as well.

## Notes

- 23 insertions / 11 deletions across two files.
- Same patch submitted upstream as DrKLO/Telegram#2097 and to Nekogram as Nekogram/Nekogram#372.
- One adjacent issue was left untouched to keep this focused: in `setPlaylist()`, `playlistMergeDialogId = mergeDialogId` is assigned immediately before `clearPlaylist()`, which resets it to `0`.
- Verified by static analysis and a parser check of the modified files. I could not run a full Gradle build (no Android SDK/NDK on this machine), so please treat on-device testing as unverified on my side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix repeat-one track selection and expanded-player artwork handling.

Bug Fixes:
- Fix repeat-one playback so it repeats the track that actually finished, including tracks selected through external playlist entry points.
- Restore missing artwork in the expanded audio player when only larger album-art thumbnails are available.

Enhancements:
- Keep the current playlist position synchronized with the active track across shuffled and rebuilt playlists.
- Reset playlist loop state during media-controller cleanup and correct playlist index validation.