### PR TITLE
fix(translator): unescape HTML entities in Google Cloud 2 translations

### DIFF
--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/transtale/source/GoogleCloud2Translator.kt
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/transtale/source/GoogleCloud2Translator.kt
@@ -1,5 +1,6 @@
 package tw.nekomimi.nekogram.transtale.source
 
+import cn.hutool.http.HtmlUtil
 import io.ktor.http.ContentType
 import org.json.JSONArray
 import org.telegram.messenger.LocaleController
@@ -45,7 +46,7 @@ object GoogleCloud2Translator : Translator {
 
         if (innerArr.length() == 0) error("Empty translation result")
 
-        return innerArr.getString(0).replace("<br h=114514>", "\n")
+        return HtmlUtil.unescape(innerArr.getString(0).replace("<br h=114514>", "\n"))
 
     }
 


### PR DESCRIPTION
Since GoogleCloud2Translator uses the translateHtml endpoint, special characters such as apostrophes (&#39;), quotes (&quot;), and ampersands (&amp;) were returned. This PR solves this issue.

an mistake happened in the old pr, i forgot to commit and force pushed: https://github.com/NextAlone/Nagram/pull/136

## Summary by Sourcery

Bug Fixes:
- Unescape HTML entities in Google Cloud 2 translation results so apostrophes, quotes, ampersands, and similar characters are returned correctly.