### PR TITLE
feat: material design 3 chat header

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/ActionBar.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/ActionBar.java
@@ -2299,7 +2299,9 @@ public class ActionBar extends FrameLayout implements FactorAnimator.Target, The
             }
 
             glassDrawable.setBounds(left, t, right, b);
-            glassDrawable.draw(canvas);
+            if (!NaConfig.INSTANCE.getMaterialDesign3ChatHeader().Bool()) {
+                glassDrawable.draw(canvas);
+            }
         }
         if (glassDrawableBack != null && hasBackButton) {
             glassDrawableBack.setBounds(0, t, s + p * 2, b);

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
@@ -323,6 +323,7 @@ private final AbstractConfigCell defaultHlsVideoQualityRow = cellGroup.appendCel
     private final AbstractConfigCell disableGlareEffectsRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getDisableGlareEffects()));
     private final AbstractConfigCell liquidGlassAngleRow = cellGroup.appendCell(new ConfigCellCustom("LiquidGlassAngle", ConfigCellCustom.CUSTOM_ITEM_LiquidGlassAngle, true));
     private final AbstractConfigCell liquidGlassIntensityRow = cellGroup.appendCell(new ConfigCellCustom("LiquidGlassIntensity", ConfigCellCustom.CUSTOM_ITEM_LiquidGlassIntensity, true));
+    private final AbstractConfigCell materialDesign3ChatHeaderRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getMaterialDesign3ChatHeader(), LocaleController.getString(R.string.MaterialDesign3ChatHeaderDes)));
     private final AbstractConfigCell dividerBlur = cellGroup.appendCell(new ConfigCellDivider());
 
     private ChatBlurAlphaSeekBar chatBlurAlphaSeekbar;
@@ -554,6 +555,8 @@ private final AbstractConfigCell defaultHlsVideoQualityRow = cellGroup.appendCel
                 tooltip.showWithAction(0, UndoView.ACTION_NEED_RESATRT, null, null);
             } else if (key.equals(NaConfig.INSTANCE.getTabStyleStroke().getKey())) {
                 getNotificationCenter().postNotificationName(NotificationCenter.dialogFiltersUpdated);
+            } else if (key.equals(NaConfig.INSTANCE.getMaterialDesign3ChatHeader().getKey())) {
+                parentLayout.rebuildAllFragmentViews(false, false);
             }
         };
 

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -1379,6 +1379,12 @@ object NaConfig {
             ConfigItem.configTypeBool,
             false
         )
+    val materialDesign3ChatHeader =
+        addConfig(
+            "MaterialDesign3ChatHeader",
+            ConfigItem.configTypeBool,
+            false
+        )
 
     private fun addConfig(
         k: String,

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -368,4 +368,6 @@
     <string name="MessagePreviewPollAnswerTerrible">Terrible</string>
     <string name="MessagePreviewPollAnswerWorse">Even worse</string>
     <string name="UseSystemFontInTitle">Use System Font in Title</string>
+    <string name="MaterialDesign3ChatHeader">Material Design 3 chat header</string>
+    <string name="MaterialDesign3ChatHeaderDes">Remove top chat header background</string>
 </resources>


### PR DESCRIPTION
added material design 3 chat header similar to exteragram. (it just removes the background of the chat header)

<img width="1080" height="2340" alt="Screenshot_20260908_182924_AyuGram" src="https://github.com/user-attachments/assets/e7dea84c-7694-41da-bbd8-d64cb3ed0357" />
<img width="1080" height="2340" alt="Screenshot_20260908_182915_AyuGram" src="https://github.com/user-attachments/assets/29d4c178-dddf-4cd2-a2e2-bbf5d24bbced" />


why? it does personally look better to me.

## Summary by Sourcery

New Features:
- Add an optional Material Design 3 chat header setting that removes the chat header background.