### PR TITLE
feat: add option to show/hide forward count

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -18692,7 +18692,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             float drawableWidth = Theme.chat_msgInViewsDrawable.getIntrinsicWidth() * (Theme.chat_timePaint.getTextSize() - dp(2)) / Theme.chat_msgInViewsDrawable.getIntrinsicHeight();
             timeWidth += viewsTextWidth + drawableWidth + dp(10);
         }
-        if (messageObject.messageOwner.forwards > 0) {
+        if (NaConfig.INSTANCE.getShowForwardCount().Bool() && messageObject.messageOwner.forwards > 0) {
             currentForwardsString = String.format("%s", LocaleController.formatShortNumber(Math.max(1, messageObject.messageOwner.forwards), null));
             forwardsTextWidth = (int) Math.ceil(Theme.chat_timePaint.measureText(currentForwardsString));
             float drawableWidth = TimeStringHelper.forwardsDrawable != null ? (TimeStringHelper.forwardsDrawable.getIntrinsicWidth() * (Theme.chat_timePaint.getTextSize() - dp(2)) / Math.max(1f, TimeStringHelper.forwardsDrawable.getIntrinsicHeight())) : 0;

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/MessagesPreviewCell.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/MessagesPreviewCell.java
@@ -174,6 +174,7 @@ public class MessagesPreviewCell extends LinearLayout {
         return NekoConfig.showSeconds.getKey().equals(key)
                 || NaConfig.INSTANCE.getShowMessageID().getKey().equals(key)
                 || NaConfig.INSTANCE.getDateOfForwardedMsg().getKey().equals(key)
+                || NaConfig.INSTANCE.getShowForwardCount().getKey().equals(key)
                 || NaConfig.INSTANCE.getShowEditedIcon().getKey().equals(key)
                 || NaConfig.INSTANCE.getCustomEditedMessage().getKey().equals(key)
                 || NaConfig.INSTANCE.getShowVoteCountBeforeVote().getKey().equals(key)

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
@@ -411,6 +411,8 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
                 MediaController.getInstance().recreateProximityWakeLock();
             } else if (key.equals(NekoConfig.showSeconds.getKey())) {
                 LocaleController.getInstance().recreateFormatters();
+            } else if (key.equals(NaConfig.INSTANCE.getShowEditedIcon().getKey())) {
+                updateRows();
             } else if (key.equals(NaConfig.INSTANCE.getDisableBotOpenButton().getKey())) {
                 tooltip.showWithAction(0, UndoView.ACTION_NEED_RESATRT, null, null);
             } else if (key.equals(NekoConfig.hideTimeForSticker.getKey()) || key.equals(NaConfig.INSTANCE.getRealHideTimeForSticker().getKey())) {
@@ -667,6 +669,11 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
     @Override
     protected void setCanNotChange() {
         super.setCanNotChange();
+
+        cellGroup.rows.remove(customEditedMessageRow);
+        if (!NaConfig.INSTANCE.getShowEditedIcon().Bool()) {
+            cellGroup.rows.add(cellGroup.rows.indexOf(showEditedIconRow) + 1, customEditedMessageRow);
+        }
 
         if (!NekoConfig.showRepeat.Bool() || NaConfig.INSTANCE.getShowRepeatAsCopy().Bool()){
             cellGroup.rows.remove(autoReplaceRepeatRow);

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
@@ -84,6 +84,7 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
     private final AbstractConfigCell showSeconds = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.showSeconds));
     private final AbstractConfigCell showMessageIDRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getShowMessageID()));
     private final AbstractConfigCell dateOfForwardMsgRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getDateOfForwardedMsg()));
+    private final AbstractConfigCell showForwardCountRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getShowForwardCount()));
     private final AbstractConfigCell showEditedIconRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getShowEditedIcon()));
     private final AbstractConfigCell customEditedMessageRow = cellGroup.appendCell(new ConfigCellTextInput(null, NaConfig.INSTANCE.getCustomEditedMessage(), "", null, null, false));
     private final AbstractConfigCell showVoteCountBeforeVoteRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getShowVoteCountBeforeVote()));

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -189,6 +189,12 @@ object NaConfig {
             ConfigItem.configTypeBool,
             false
         )
+    val showForwardCount =
+        addConfig(
+            "ShowForwardCount",
+            ConfigItem.configTypeBool,
+            true
+        )
     val showMessageID =
         addConfig(
             "ShowMessageID",

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
@@ -30,6 +30,7 @@
     <string name="PhotoCopied">图片已复制到剪贴板</string>
     <string name="ToTheBeginning">回到顶部</string>
     <string name="DateOfForwardedMsg">显示转发消息日期</string>
+    <string name="ShowForwardCount">显示转发次数</string>
     <string name="ShowMessageID">显示消息 ID</string>
     <string name="ShowRPCError">显示 RPC 错误</string>
     <string name="ShowServicesTime">显示服务消息时间</string>

--- a/TMessagesProj/src/main/res/values-zh-rTW/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rTW/strings_na.xml
@@ -30,6 +30,7 @@
     <string name="PhotoCopied">圖片已複製到剪貼簿</string>
     <string name="ToTheBeginning">回到頂部</string>
     <string name="DateOfForwardedMsg">顯示轉發訊息日期</string>
+    <string name="ShowForwardCount">顯示轉發次數</string>
     <string name="ShowMessageID">顯示訊息 ID</string>
     <string name="ShowRPCError">顯示 RPC 錯誤</string>
     <string name="ShowServicesTime">顯示服務訊息時間</string>

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -30,6 +30,7 @@
     <string name="PhotoCopied">Photo copied to Clipboard</string>
     <string name="ToTheBeginning">To the beginning</string>
     <string name="DateOfForwardedMsg">Show date of forward message</string>
+    <string name="ShowForwardCount">Show forward count</string>
     <string name="ShowMessageID">Show message ID</string>
     <string name="ShowRPCError">Toast all RPC errors</string>
     <string name="ShowServicesTime">Show timestamp in service messages</string>


### PR DESCRIPTION
forward count is now optional; "custom edited message word" hides when "show icon instead of edited" is on for better UI

## Summary by Sourcery

Add message display settings for controlling forward counts and streamline the edited-message customization options.

New Features:
- Add a configurable option to show or hide forward counts in message metadata, enabled by default.

Enhancements:
- Hide the custom edited-message text setting when the edited icon display is enabled and update settings rows when that option changes.