### PR TITLE
fix(translator): prevent extra spaces in Google Cloud 2

### DIFF
--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/transtale/source/GoogleCloud2Translator.kt
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/transtale/source/GoogleCloud2Translator.kt
@@ -17,7 +17,7 @@ object GoogleCloud2Translator : Translator {
         }
 
         val srclang = from.ifEmpty { "auto" }
-        val content = query.replace("\n", "<br h=114514>")
+        val content = query.replace("\n", "<span class=\"notranslate\">\n</span>")
 
         val jsonBody = JSONArray().apply {
             put(JSONArray().apply {
@@ -46,7 +46,7 @@ object GoogleCloud2Translator : Translator {
 
         if (innerArr.length() == 0) error("Empty translation result")
 
-        return HtmlUtil.unescape(innerArr.getString(0).replace("<br h=114514>", "\n"))
+        return HtmlUtil.unescape(innerArr.getString(0).replace("<span class=\"notranslate\">\n</span>", "\n"))
 
     }
 


### PR DESCRIPTION
Fixed the issue google cloud inserting spaces.

## Summary by Sourcery

Bug Fixes:
- Prevent Google Cloud 2 translations from adding unwanted spaces around preserved newlines.