### PR TITLE
fix: allow holiday hat to be drawn on custom title drawable

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/ActionBar.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/ActionBar.java
@@ -413,7 +413,7 @@ public class ActionBar extends FrameLayout implements FactorAnimator.Target, The
             Drawable drawable = Theme.getCurrentHolidayDrawable();
             if (drawable != null) {
                 SimpleTextView titleView = child == titlesContainer ? titleTextView[0] : (SimpleTextView) child;
-                if (titleView != null && titleView.getVisibility() == View.VISIBLE && titleView.getText() instanceof String) {
+                if (titleView != null && titleView.getVisibility() == View.VISIBLE && titleView.getText() != null && titleView.getText().length() > 0) {
                     TextPaint textPaint = titleView.getTextPaint();
                     textPaint.getFontMetricsInt(fontMetricsInt);
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {


### PR DESCRIPTION
In ActionBar, the holiday drawable rendering logic previously required titleView.getText() to be an instanceof String. When Use System Font in Title is disabled, the title is passed as a SpannableStringBuilder containing the custom logo ImageSpan, causing the check to fail. This PR solves this issue.

## Summary by Sourcery

Bug Fixes:
- Allow holiday hat artwork to render for non-empty custom title drawables, including titles represented by spannable text.