### PR TITLE
feat(iv): add option to disable AI summary in Instant View

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ArticleViewer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ArticleViewer.java
@@ -243,6 +243,7 @@ import cn.hutool.core.util.StrUtil;
 import tw.nekomimi.nekogram.NekoConfig;
 import tw.nekomimi.nekogram.parts.ArticleTransKt;
 import tw.nekomimi.nekogram.transtale.TranslateDb;
+import xyz.nextalone.nagram.NaConfig;
 
 public class ArticleViewer extends IArticleViewer implements NotificationCenter.NotificationCenterDelegate {
 
@@ -1989,9 +1990,14 @@ public class ArticleViewer extends IArticleViewer implements NotificationCenter.
 
             int numBlocks = 0;
             int count = webPage.cached_page.blocks.size();
+            boolean firstBlock = true;
             for (int a = 0; a < count; a++) {
                 TL_iv.PageBlock block = webPage.cached_page.blocks.get(a);
-                if (a == 0) {
+                if (NaConfig.INSTANCE.getDisableInstantViewAiSummary().Bool() && isAiSummaryBlock(block)) {
+                    continue;
+                }
+                if (firstBlock) {
+                    firstBlock = false;
                     block.first = true;
                     if (block instanceof TL_iv.pageBlockCover) {
                         TL_iv.pageBlockCover pageBlockCover = (TL_iv.pageBlockCover) block;
@@ -3168,6 +3174,54 @@ public class ArticleViewer extends IArticleViewer implements NotificationCenter.
             return ((TL_iv.textPhone) richText).phone;
         }
         return null;
+    }
+
+    public static boolean isAiSummaryBlock(TL_iv.PageBlock block) {
+        if (block == null) {
+            return false;
+        }
+        if (block instanceof TL_pageBlockDetailsChild) {
+            TL_pageBlockDetailsChild child = (TL_pageBlockDetailsChild) block;
+            return isAiSummaryBlock(child.parent) || isAiSummaryBlock(child.block);
+        }
+        if (block instanceof TL_iv.pageBlockThinking) {
+            return true;
+        }
+        if (block instanceof TL_iv.pageBlockDetails) {
+            TL_iv.pageBlockDetails details = (TL_iv.pageBlockDetails) block;
+            if (details.blocks != null) {
+                for (int i = 0, size = details.blocks.size(); i < size; i++) {
+                    if (details.blocks.get(i) instanceof TL_iv.pageBlockThinking) {
+                        return true;
+                    }
+                }
+            }
+            if (details.title != null) {
+                CharSequence cs = getPlainText(details.title);
+                if (cs != null) {
+                    String title = cs.toString().trim().toLowerCase();
+                    if (title.contains("ai summary")
+                            || title.contains("ai 总结")
+                            || title.contains("ai总结")
+                            || title.contains("ai 摘要")
+                            || title.contains("ai摘要")
+                            || title.contains("пересказ")
+                            || title.contains("краткое содержание")
+                            || ((title.contains("ai") || title.contains("ia") || title.contains("ki")) && (title.contains("summar") || title.contains("recap") || title.contains("resum") || title.contains("zusammenfass") || title.contains("riassunt")))
+                            || title.equals("summary")) {
+                        return true;
+                    }
+                    try {
+                        String localized = LocaleController.getString("SummaryTitle", R.string.SummaryTitle);
+                        if (!TextUtils.isEmpty(localized) && title.contains(localized.trim().toLowerCase())) {
+                            return true;
+                        }
+                    } catch (Exception ignored) {
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     @Override
@@ -6684,6 +6738,9 @@ public class ArticleViewer extends IArticleViewer implements NotificationCenter.
         }
 
         private void addBlock(WebpageAdapter adapter, TL_iv.PageBlock block, int level, int listLevel, int position) {
+            if (NaConfig.INSTANCE.getDisableInstantViewAiSummary().Bool() && isAiSummaryBlock(block)) {
+                return;
+            }
             TL_iv.PageBlock originalBlock = block;
             if (block instanceof TL_pageBlockDetailsChild) {
                 TL_pageBlockDetailsChild blockDetailsChild = (TL_pageBlockDetailsChild) block;

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
@@ -119,6 +119,7 @@ public class NekoGeneralSettingsActivity extends BaseNekoXSettingsActivity {
                     LocaleController.getString(R.string.SummarizeTextButtonAlways),
             }, null));
     private final AbstractConfigCell disableAiEditorRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getDisableAiEditor()));
+    private final AbstractConfigCell disableInstantViewAiSummaryRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getDisableInstantViewAiSummary()));
     private final AbstractConfigCell dividerAiTools = cellGroup.appendCell(new ConfigCellDivider());
 
     private final AbstractConfigCell headerMap = cellGroup.appendCell(new ConfigCellHeader("Map"));

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -1331,6 +1331,12 @@ object NaConfig {
             ConfigItem.configTypeBool,
             false
         )
+    val disableInstantViewAiSummary =
+        addConfig(
+            "DisableInstantViewAiSummary",
+            ConfigItem.configTypeBool,
+            false
+        )
     val disableGlareEffects =
         addConfig(
             "DisableGlareEffects",

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_na.xml
@@ -349,6 +349,7 @@
     <string name="ShowRecentForwardTab">转发时显示最近会话</string>
     <string name="ProviderVolcengineTranslate">火山引擎</string>
     <string name="DisableAiEditor">禁用 AI 编辑器</string>
+    <string name="DisableInstantViewAiSummary">禁用即时预览 AI 总结</string>
     <string name="DisableGlareEffects">禁用炫光效果</string>
     <string name="ShowEditedIcon">显示图标而不是 \"已编辑\"</string>
     <string name="DeleteCloudBackup">清除云数据</string>

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -350,6 +350,7 @@
     <string name="ShowRecentForwardTab">Show recent chats tab when forwarding</string>
     <string name="ProviderVolcengineTranslate">Volcengine Translate</string>
     <string name="DisableAiEditor">Disable Ai Editor</string>
+    <string name="DisableInstantViewAiSummary">Disable AI summary in Instant View</string>
     <string name="DisableGlareEffects">Disable Glare effects</string>
     <string name="ShowEditedIcon">Show icon instead of \"edited\"</string>
     <string name="DeleteCloudBackup">Clear cloud data</string>


### PR DESCRIPTION
Telegram automatically injects AI-generated summaries at the top of Instant View pages as
  collapsible details blocks. This commit introduces a user toggle to disable and hide these summaries.

Changes included:
    - NaConfig: Added boolean configuration `disableInstantViewAiSummary`.
    - Settings UI: Added a toggle switch under the "AI Tools" section in NekoGeneralSettingsActivity.
    - ArticleViewer:
      - Added `isAiSummaryBlock()` helper to detect AI summary details blocks (matching localized summary titles and containing thinking blocks) as well as standalone `TL_iv.pageBlockThinking` blocks.
      - Filtered out matching summary blocks in `showArticle()` and `WebpageAdapter.addBlock()`, properly adjusting the first content block rendering when the summary is omitted.
    - Localization: Added string resource in strings_na.xml and Simplified Chinese translation in values- zh-rCN/strings_na.xml.

## Summary by Sourcery

Allow users to disable AI summaries in Instant View through a new AI Tools preference.

New Features:
- Add a setting to disable AI-generated summaries in Instant View pages.

Enhancements:
- Hide detected Instant View AI summary content while preserving correct rendering of the remaining article content.

Chores:
- Add English and Simplified Chinese labels for the new setting.