### PR TITLE
fix(network): do not truncate response body in NetworkRequestBuilder

### DIFF
--- a/TMessagesProj/src/main/java/xyz/nextalone/nagram/network/NetworkLogManager.kt
+++ b/TMessagesProj/src/main/java/xyz/nextalone/nagram/network/NetworkLogManager.kt
@@ -283,9 +283,6 @@ class NetworkRequestBuilder(
                         responseBody = responseBodyBytes!!.toString(Charsets.UTF_8)
                     } else {
                         responseBody = response.bodyAsText()
-                        if (responseBody.length > 10000) {
-                            responseBody = responseBody.take(10000) + "\n... (truncated)"
-                        }
                     }
                 } catch (e: Exception) {
                     responseBody = "Unable to read response body: ${e.message}"


### PR DESCRIPTION
Do not truncate responseBody at 10,000 characters in NetworkRequestBuilder.execute(). Truncation corrupted large response payloads such as Google Cloud 2 translations, leading to JSON parsing errors (e.g. unterminated string).

## Summary by Sourcery

Bug Fixes:
- Preserve complete network response bodies so large payloads remain valid and can be parsed without truncation-related errors.