### PR TITLE
fix(translator): retain original text when message translation fails

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
@@ -6084,7 +6084,7 @@ public class MessageObject {
                         }
                     }
                 }
-            } else if (messageOwner.translated) {
+            } else if (messageOwner.translated && !TextUtils.isEmpty(messageOwner.translatedMessage)) {
                 messageText = messageOwner.translatedMessage;
             } else {
                 if (messageOwner.message != null) {

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/parts/MessageTrans.kt
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/parts/MessageTrans.kt
@@ -64,7 +64,7 @@ fun MessageObject.translateFinished(locale: Locale): Int {
         messageOwner.translatedPoll = translatedPoll
     } else {
 
-        val text = db.query(messageOwner.message.takeIf { !it.isNullOrBlank() } ?: return 1)
+        val text = db.query(messageOwner.message.takeIf { !it.isNullOrBlank() } ?: return 1)?.takeIf { it.isNotBlank() }
                 ?: return 0
 
         messageOwner.translatedMessage =
@@ -144,9 +144,14 @@ fun ChatActivity.translateMessages(
                     }
                 }
                 else -> deferreds.add(async(transPool) {
-                    translateMessage(selectedObject, target, context, cancel, status)
+                    val success = translateMessage(selectedObject, target, context, cancel, status)
                     if (!cancel.get()) {
-                        selectedObject.messageOwner.translated = true
+                        if (success) {
+                            selectedObject.messageOwner.translated = true
+                        } else {
+                            selectedObject.messageOwner.translated = false
+                            selectedObject.messageOwner.translatedMessage = selectedObject.messageOwner.message
+                        }
                         next()
                         withContext(Dispatchers.Main) {
                             messageHelper.resetMessageContent(dialogId, selectedObject)
@@ -169,9 +174,9 @@ private suspend fun ChatActivity.translateMessage(
     context: List<String>,
     cancel: AtomicBoolean,
     status: AlertDialog?
-) {
+): Boolean {
     val db = TranslateDb.forLocale(target)
-    if (message.isPoll) {
+    return if (message.isPoll) {
         translatePoll(message, target, context, db, cancel, status)
     } else {
         translateText(message, target, context, db, cancel, status)
@@ -185,16 +190,16 @@ private suspend fun ChatActivity.translatePoll(
     db: TranslateDb,
     cancel: AtomicBoolean,
     status: AlertDialog?
-) {
+): Boolean {
     val pool = (message.messageOwner.media as TLRPC.TL_messageMediaPoll).poll
-    var question = if (context.isEmpty()) db.query(pool.question.text) else null
+    var question = if (context.isEmpty()) db.query(pool.question.text)?.takeIf { it.isNotBlank() } else null
     if (question == null) {
-        if (cancel.get()) return
+        if (cancel.get()) return false
         question = runCatching {
             Translator.translate(target, pool.question.text, context)
         }.getOrElse {
             handleError(target, it, cancel, status)
-            return
+            return false
         }
     }
 
@@ -204,15 +209,15 @@ private suspend fun ChatActivity.translatePoll(
         append(question)
     }
 
-    translatedPoll.answers.forEach {
-        var answer = if (context.isEmpty()) db.query(it.text.text) else null
+    for (it in translatedPoll.answers) {
+        var answer = if (context.isEmpty()) db.query(it.text.text)?.takeIf { it.isNotBlank() } else null
         if (answer == null) {
-            if (cancel.get()) return@forEach
+            if (cancel.get()) return false
             answer = runCatching {
                 Translator.translate(target, it.text.text, context)
             }.getOrElse { e ->
                 handleError(target, e, cancel, status)
-                return@forEach
+                return false
             }
         }
         it.text.text = buildString {
@@ -222,14 +227,14 @@ private suspend fun ChatActivity.translatePoll(
     }
 
     translatedPoll.solution?.let { solution ->
-        var translatedSolution = if (context.isEmpty()) db.query(solution.text) else null
+        var translatedSolution = if (context.isEmpty()) db.query(solution.text)?.takeIf { it.isNotBlank() } else null
         if (translatedSolution == null) {
-            if (cancel.get()) return
+            if (cancel.get()) return false
             translatedSolution = runCatching {
                 Translator.translate(target, solution.text, context)
             }.getOrElse {
                 handleError(target, it, cancel, status)
-                return
+                return false
             }
         }
         solution.text = buildString {
@@ -239,6 +244,7 @@ private suspend fun ChatActivity.translatePoll(
     }
 
     message.messageOwner.translatedPoll = translatedPoll
+    return true
 }
 
 private suspend fun ChatActivity.translateText(
@@ -248,21 +254,32 @@ private suspend fun ChatActivity.translateText(
     db: TranslateDb,
     cancel: AtomicBoolean,
     status: AlertDialog?
-) {
-    var text = if (context.isEmpty()) db.query(message.messageOwner.message) else null
+): Boolean {
+    val originalMessage = message.messageOwner?.message
+    if (originalMessage.isNullOrBlank()) {
+        return false
+    }
+    var text = if (context.isEmpty()) db.query(originalMessage)?.takeIf { it.isNotBlank() } else null
     if (text == null) {
         text = runCatching {
-            Translator.translate(target, message.messageOwner.message, context)
+            Translator.translate(target, originalMessage, context)
         }.getOrElse {
             handleError(target, it, cancel, status)
-            return
+            message.messageOwner.translatedMessage = originalMessage
+            return false
         }
     }
 
+    if (text.isBlank()) {
+        message.messageOwner.translatedMessage = originalMessage
+        return false
+    }
+
     message.messageOwner.translatedMessage = buildString {
-        if (!NaConfig.hideOriginAfterTranslation.Bool()) append(message.messageOwner.message + "\n\n--------\n\n")
+        if (!NaConfig.hideOriginAfterTranslation.Bool()) append(originalMessage + "\n\n--------\n\n")
         append(text)
     }
+    return true
 }
 
 private fun ChatActivity.handleError(


### PR DESCRIPTION
Thank to @claude. The Desktop Version.

Bug fix, not more feature:
https://github.com/NextAlone/Nagram/pull/148#issuecomment-5616679048

fix: handle translation failures gracefully in MessageObject

- Skip marking messages as translated when translation throws or fails
- Fall back to original message content upon translation failure
- Guard against null or empty translatedMessage in MessageObject

## Summary by Sourcery

Handle translation failures gracefully by retaining original message content and preventing failed translations from being marked as translated.

Bug Fixes:
- Preserve and restore original message content when text or poll translation fails, is cancelled, or produces empty output.
- Only mark messages as translated after a successful non-empty translation.

Enhancements:
- Guard message rendering against null or empty translated content and fall back to the original message.